### PR TITLE
ci: dependency scanning + SHA-pinned actions + NuGet audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot: weekly update PRs for GitHub Actions and NuGet packages.
+# Security updates are opened automatically once "Dependabot alerts" is enabled on the repo
+# (Settings -> Code security). Grouped so each ecosystem lands as a single PR, not one per package.
+version: 2
+updates:
+  # GitHub Actions referenced in .github/workflows/*
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # NuGet packages for the app project
+  - package-ecosystem: "nuget"
+    directory: "/src/HASS.Agent.NET10"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      nuget:
+        patterns: ["*"]

--- a/.github/workflows/hass-agent-net10.yml
+++ b/.github/workflows/hass-agent-net10.yml
@@ -29,8 +29,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  audit:
+    name: NuGet vulnerability audit
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: 10.0.x
+      - name: Restore
+        run: dotnet restore src/HASS.Agent.sln
+      - name: Audit (fail on vulnerable packages)
+        shell: bash
+        run: |
+          dotnet list src/HASS.Agent.sln package --vulnerable --include-transitive 2>&1 | tee audit.txt
+          if grep -q 'has the following vulnerable' audit.txt; then
+            echo "::error::Vulnerable NuGet packages found (see log above)"; exit 1
+          fi
+          echo "No vulnerable NuGet packages."
+
   build:
     name: Build and publish
+    needs: audit
     runs-on: windows-latest
 
     env:
@@ -43,10 +67,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 10.0.x
 
@@ -89,14 +115,14 @@ jobs:
       - name: Upload unsigned app executable
         if: env.SIGNPATH_ENABLED == 'true'
         id: unsigned-exe
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unsigned-app-exe
           path: ${{ env.PUBLISH_DIR }}/HASS.Agent.NET10.exe
 
       - name: Sign app executable
         if: env.SIGNPATH_ENABLED == 'true'
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORG_ID }}
@@ -120,14 +146,14 @@ jobs:
       - name: Upload unsigned installer
         if: env.SIGNPATH_ENABLED == 'true'
         id: unsigned-installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unsigned-installer-exe
           path: artifacts/installer/*.exe
 
       - name: Sign installer
         if: env.SIGNPATH_ENABLED == 'true'
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORG_ID }}
@@ -144,21 +170,21 @@ jobs:
 
       - name: Upload published app
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: HASS.Agent.NET10-win-x64
           path: artifacts/HASS.Agent.NET10/win-x64
 
       - name: Upload installer
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: HASS.Agent.NET10-Setup
           path: artifacts/installer/*.exe
 
       - name: Upload release assets
         if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## CI security hardening

Same setup as RemoteAppClient, adapted to this repo.

### Changes
- **`.github/dependabot.yml`** — weekly, grouped update PRs for **GitHub Actions** and **NuGet** (the `HASS.Agent.NET10` project). With Dependabot alerts enabled, security PRs come automatically too.
- **SHA-pinned actions** in `hass-agent-net10.yml` — every `uses:` pinned to a full commit SHA (with a `# vX.Y.Z` comment): checkout, setup-dotnet, upload-artifact, signpath, gh-release. Plus `persist-credentials: false` on checkout. Pinned to the current major (v4/v2); Dependabot will propose major bumps as reviewable PRs.
- **NuGet audit gate** — a new `audit` job runs `dotnet list package --vulnerable --include-transitive` and **fails the build** on any vulnerable package; the `build` job now `needs: audit`.

### Notes
- Current scan is clean (no vulnerable packages).
- No EF/Pomelo here, so no provider-pairing ignore needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for GitHub Actions and NuGet packages
  * Enhanced build pipeline with vulnerability scanning for package dependencies
  * Updated workflow actions to use pinned versions for improved reproducibility and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->