### PR TITLE
Add command sensors with optional unit (10.6.0-beta.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.0--beta.2-orange)
+![Version](https://img.shields.io/badge/version-10.6.0--beta.3-orange)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -54,6 +54,10 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.0-beta.3
+
+- Added **command sensors**: a custom sensor whose value is the output of a program or PowerShell script you run on the PC — e.g. GPU temperature via `nvidia-smi`, or anything else that prints a value. Three types: **Command (program)** runs an executable directly, **Command (PowerShell)** and **Command (PowerShell 7)** run an inline command or a `.ps1`. The first non-empty line of the output becomes the sensor value (numbers are published numerically). An optional **Unit** column shows the unit in Home Assistant and marks the sensor as a numeric `measurement` for statistics/graphs. Commands run with a timeout so a hung command can't stall reporting; use the Normal/Hourly polling profile. Like custom command buttons, you define what runs — Home Assistant only reads the resulting value. No Home Assistant integration update needed.
 
 ### 10.6.0-beta.2
 
@@ -489,6 +493,30 @@ Parameter: network_address.addresses[1].address
 ```text
 Name: "Last shutdown"
 Parameter: last_shutdown_reason.reason
+```
+
+#### `command` / `command_powershell` / `command_pwsh`
+
+Runs a program or PowerShell script and uses its **output** as the sensor value — for anything Windows has no built-in sensor for, such as GPU temperature.
+
+| Type | Parameter | Runs as |
+|------|-----------|---------|
+| **Command (program)** | A program or full command line (e.g. `nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits`) | The executable directly (fast, no shell) |
+| **Command (PowerShell)** | An inline command or a `.ps1` path | `powershell.exe -NoProfile -ExecutionPolicy Bypass` |
+| **Command (PowerShell 7)** | Same as above | `pwsh.exe -NoProfile -ExecutionPolicy Bypass` |
+
+- The **first non-empty line** of the output (trimmed, max 255 chars) becomes the sensor state — format your command to print a single value. A plain number is published as a numeric value.
+- Set an optional **Unit** (e.g. `°C`) to show it in Home Assistant; a unit also marks the sensor as a numeric `measurement`, so Home Assistant keeps long-term statistics and graphs it.
+- Each run has a timeout (~10 s) so a hung command can't stall reporting. Pick the **Normal** or **Hourly** profile, not Fast.
+- **Security**: you define what runs — Home Assistant only reads the resulting value, it cannot send commands. No Home Assistant integration update is required for these.
+
+```text
+Name: "GPU temperature"
+Type: Command (program)
+Parameter: nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits
+Unit: °C
+Profile: normal
+State: 54 °C
 ```
 
 ---

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.0-beta.2"
+#define MyAppVersion "10.6.0-beta.3"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.0-beta.2</Version>
+    <Version>10.6.0-beta.3</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Localization/Strings.en.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.en.cs
@@ -181,6 +181,7 @@ internal static partial class Strings
             ["Sensors.Type"] = "Type",
             ["Sensors.Name"] = "Name",
             ["Sensors.Parameter"] = "Parameter",
+            ["Sensors.Unit"] = "Unit",
             ["Sensors.Profile"] = "Profile",
             ["Sensors.Value"] = "Value",
             ["Sensors.Add"] = "Add",
@@ -193,7 +194,7 @@ internal static partial class Strings
             ["Sensors.CustomRemove"] = "Remove custom",
             ["Sensors.MultiValueTooltip"] = "This sensor has additional values. Click to add a custom sensor from an attribute.",
             ["Sensors.AttributeSensorName"] = "{0}: {1}",
-            ["Sensors.CustomHelp"] = "Parameters: process_running = process name, service_status = Windows service name, disk_free = drive letter/path. For built-in attributes, click + on a built-in sensor; every available attribute is added with [0] for list values.",
+            ["Sensors.CustomHelp"] = "Parameters: process_running = process name, service_status = Windows service name, disk_free = drive letter/path. Command types = the program/command line (e.g. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); the first line of its output becomes the value — use the Normal/Hourly profile. For built-in attributes, click + on a built-in sensor; every available attribute is added with [0] for list values.",
             ["Sensors.ValueLoading"] = "reading...",
             ["Sensors.ValueNotTested"] = "not tested",
             ["Sensors.ValueMissingParameter"] = "missing parameter",
@@ -319,5 +320,8 @@ internal static partial class Strings
             ["SensorType.service_status"] = "Service status",
             ["SensorType.disk_free"] = "Disk free space",
             ["SensorType.built_in_attribute"] = "Built-in attribute",
+            ["SensorType.command"] = "Command (program)",
+            ["SensorType.command_powershell"] = "Command (PowerShell)",
+            ["SensorType.command_pwsh"] = "Command (PowerShell 7)",
     };
 }

--- a/src/HASS.Agent.NET10/Localization/Strings.hu.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.hu.cs
@@ -181,6 +181,7 @@ internal static partial class Strings
             ["Sensors.Type"] = "Típus",
             ["Sensors.Name"] = "Név",
             ["Sensors.Parameter"] = "Paraméter",
+            ["Sensors.Unit"] = "M.egys.",
             ["Sensors.Profile"] = "Profil",
             ["Sensors.Value"] = "Érték",
             ["Sensors.Add"] = "Hozzáadás",
@@ -193,7 +194,7 @@ internal static partial class Strings
             ["Sensors.CustomRemove"] = "Egyedi törlés",
             ["Sensors.MultiValueTooltip"] = "Ez a szenzor több értéket is ad. Kattints egy attribútum alapú egyedi szenzor hozzáadásához.",
             ["Sensors.AttributeSensorName"] = "{0}: {1}",
-            ["Sensors.CustomHelp"] = "Paraméterek: process_running = processz név, service_status = Windows service név, disk_free = meghajtó betűjel/útvonal. Beépített attribútumhoz kattints a + ikonra; minden elérhető attribútum bekerül, listáknál [0] indexszel.",
+            ["Sensors.CustomHelp"] = "Paraméterek: process_running = processz név, service_status = Windows service név, disk_free = meghajtó betűjel/útvonal. Parancs típusok = a program/parancssor (pl. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); a kimenet első sora lesz az érték — használd a Normál/Óránkénti profilt. Beépített attribútumhoz kattints a + ikonra; minden elérhető attribútum bekerül, listáknál [0] indexszel.",
             ["Sensors.ValueLoading"] = "olvasás...",
             ["Sensors.ValueNotTested"] = "nincs tesztelve",
             ["Sensors.ValueMissingParameter"] = "hiányzó paraméter",
@@ -319,5 +320,8 @@ internal static partial class Strings
             ["SensorType.service_status"] = "Szolgáltatás állapot",
             ["SensorType.disk_free"] = "Szabad lemezterület",
             ["SensorType.built_in_attribute"] = "Beépített attribútum",
+            ["SensorType.command"] = "Parancs (program)",
+            ["SensorType.command_powershell"] = "Parancs (PowerShell)",
+            ["SensorType.command_pwsh"] = "Parancs (PowerShell 7)",
     };
 }

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -1495,23 +1495,35 @@ internal sealed class MqttCompanionService : IDisposable
     {
         return _settings.CustomSensors
             .Where(sensor => sensor.Enabled && (serviceRole ? sensor.Service : sensor.TrayApp))
-            .Select(sensor => new CustomSensorDescriptor(
+            .Select(sensor =>
+            {
+                // A user-set unit (e.g. °C on a command sensor) wins; disk_free keeps its
+                // built-in GiB. Any sensor that carries a unit is a numeric measurement.
+                var unit = !string.IsNullOrWhiteSpace(sensor.Unit)
+                    ? sensor.Unit.Trim()
+                    : (sensor.IsDiskFree ? "GiB" : null);
+
+                return new CustomSensorDescriptor(
                 sensor.Id,
                 sensor.Type,
                 sensor.Name,
                 sensor.Parameter,
                 SensorPollingProfiles.NormalizeKey(sensor.PollingProfile, SensorPollingProfile.Normal),
-                sensor.IsDiskFree ? "GiB" : null,
+                unit,
                 null,
-                sensor.IsDiskFree ? "measurement" : null,
+                unit is not null ? "measurement" : null,
                 sensor.Type switch
                 {
                     CustomSensorTypes.ProcessRunning => "mdi:application-cog",
                     CustomSensorTypes.ServiceStatus => "mdi:cog-sync",
                     CustomSensorTypes.DiskFree => "mdi:harddisk",
                     CustomSensorTypes.BuiltInAttribute => "mdi:table-column-plus-after",
+                    CustomSensorTypes.Command => "mdi:console",
+                    CustomSensorTypes.CommandPowerShell => "mdi:powershell",
+                    CustomSensorTypes.CommandPwsh => "mdi:powershell",
                     _ => "mdi:gauge"
-                }))
+                });
+            })
             .ToList();
     }
 

--- a/src/HASS.Agent.NET10/SystemCommands/SystemCommandService.cs
+++ b/src/HASS.Agent.NET10/SystemCommands/SystemCommandService.cs
@@ -148,7 +148,7 @@ internal sealed class SystemCommandService : IDisposable
     // inline arguments. A quoted path, or an unquoted path that exists as-is, is kept
     // whole so paths containing spaces still work; otherwise the first whitespace-
     // delimited token is treated as the executable.
-    private static (string FileName, string Arguments) SplitProcessCommand(string command)
+    internal static (string FileName, string Arguments) SplitProcessCommand(string command)
     {
         var trimmed = (command ?? string.Empty).Trim();
         if (trimmed.Length == 0)

--- a/src/HASS.Agent.NET10/SystemStatus/CustomSensorDefinition.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/CustomSensorDefinition.cs
@@ -12,6 +12,10 @@ internal sealed class CustomSensorDefinition
 
     public string Parameter { get; set; } = string.Empty;
 
+    // Optional unit of measurement (e.g. "°C"). When set, the sensor is advertised as a
+    // numeric measurement, so Home Assistant shows the unit and keeps long-term statistics.
+    public string Unit { get; set; } = string.Empty;
+
     public string PollingProfile { get; set; } = SensorPollingProfiles.ToKey(SensorPollingProfile.Normal);
 
     public bool Enabled { get; set; } = true;
@@ -33,6 +37,18 @@ internal sealed class CustomSensorDefinition
     public bool IsBuiltInAttribute => string.Equals(Type, CustomSensorTypes.BuiltInAttribute, StringComparison.OrdinalIgnoreCase);
 
     [JsonIgnore]
+    public bool IsCommand => string.Equals(Type, CustomSensorTypes.Command, StringComparison.OrdinalIgnoreCase);
+
+    [JsonIgnore]
+    public bool IsCommandPowerShell => string.Equals(Type, CustomSensorTypes.CommandPowerShell, StringComparison.OrdinalIgnoreCase);
+
+    [JsonIgnore]
+    public bool IsCommandPwsh => string.Equals(Type, CustomSensorTypes.CommandPwsh, StringComparison.OrdinalIgnoreCase);
+
+    [JsonIgnore]
+    public bool IsAnyCommand => IsCommand || IsCommandPowerShell || IsCommandPwsh;
+
+    [JsonIgnore]
     public SensorPollingProfile EffectivePollingProfile => SensorPollingProfiles.FromKey(PollingProfile, SensorPollingProfile.Normal);
 }
 
@@ -42,13 +58,19 @@ internal static class CustomSensorTypes
     public const string ServiceStatus = "service_status";
     public const string DiskFree = "disk_free";
     public const string BuiltInAttribute = "built_in_attribute";
+    public const string Command = "command";
+    public const string CommandPowerShell = "command_powershell";
+    public const string CommandPwsh = "command_pwsh";
 
     public static IReadOnlySet<string> All { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         ProcessRunning,
         ServiceStatus,
         DiskFree,
-        BuiltInAttribute
+        BuiltInAttribute,
+        Command,
+        CommandPowerShell,
+        CommandPwsh
     };
 
     public static string Normalize(string value)

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
+using System.Globalization;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -13,6 +14,7 @@ using Microsoft.Win32;
 using System.Windows.Forms;
 using HASS.Agent.Companion.Logging;
 using HASS.Agent.Companion.Media;
+using HASS.Agent.Companion.SystemCommands;
 
 namespace HASS.Agent.Companion.SystemStatus;
 
@@ -863,7 +865,7 @@ internal sealed class SystemMetricsService : IDisposable
     /// </summary>
     public static object? TestCustomSensorValue(CustomSensorDefinition sensor, FileLog log)
     {
-        if (sensor.IsProcessRunning || sensor.IsServiceStatus || sensor.IsDiskFree)
+        if (sensor.IsProcessRunning || sensor.IsServiceStatus || sensor.IsDiskFree || sensor.IsAnyCommand)
         {
             var empty = new Dictionary<string, IReadOnlyDictionary<string, object?>>();
             return ReadCustomSensor(sensor, empty).Value;
@@ -928,6 +930,11 @@ internal sealed class SystemMetricsService : IDisposable
             {
                 return new CustomSensorState(sensor.Id, ReadBuiltInAttributeValue(sensor.Parameter, attributes));
             }
+
+            if (sensor.IsAnyCommand)
+            {
+                return new CustomSensorState(sensor.Id, ReadCommandSensorValue(sensor));
+            }
         }
         catch
         {
@@ -935,6 +942,102 @@ internal sealed class SystemMetricsService : IDisposable
         }
 
         return new CustomSensorState(sensor.Id, null);
+    }
+
+    // A command sensor runs a program (or PowerShell / pwsh command / .ps1) and uses its
+    // captured stdout as the value. The command is defined by the user; Home Assistant
+    // only reads the resulting value. Runs with a bounded wait so a hung command cannot
+    // stall the polling thread.
+    private const int CommandSensorTimeoutMs = 10_000;
+
+    private static object? ReadCommandSensorValue(CustomSensorDefinition sensor)
+    {
+        var parameter = sensor.Parameter?.Trim() ?? string.Empty;
+        if (parameter.Length == 0)
+        {
+            return null;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            UseShellExecute = false
+        };
+
+        if (sensor.IsCommandPowerShell || sensor.IsCommandPwsh)
+        {
+            startInfo.FileName = sensor.IsCommandPwsh ? "pwsh.exe" : "powershell.exe";
+            var isScriptFile = parameter.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase);
+            startInfo.Arguments = isScriptFile
+                ? $"-NoProfile -ExecutionPolicy Bypass -File \"{parameter}\""
+                : $"-NoProfile -ExecutionPolicy Bypass -Command \"{parameter}\"";
+        }
+        else
+        {
+            var (fileName, arguments) = SystemCommandService.SplitProcessCommand(parameter);
+            startInfo.FileName = fileName;
+            startInfo.Arguments = arguments;
+        }
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return null;
+        }
+
+        // Read stdout before waiting so a large output cannot fill the pipe and deadlock.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        if (!process.WaitForExit(CommandSensorTimeoutMs))
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Ignore — the process may already be exiting.
+            }
+
+            return null;
+        }
+
+        var output = stdoutTask.GetAwaiter().GetResult();
+        return ExtractFirstLine(output);
+    }
+
+    private static object? ExtractFirstLine(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return null;
+        }
+
+        foreach (var line in output.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            // Publish a numeric value when the output is a plain number (invariant culture),
+            // so a unit + measurement state class produces a proper numeric HA sensor.
+            if (long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+            {
+                return longValue;
+            }
+
+            if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue))
+            {
+                return doubleValue;
+            }
+
+            return trimmed.Length <= 255 ? trimmed : trimmed[..255];
+        }
+
+        return null;
     }
 
     private static object? ReadBuiltInAttributeValue(

--- a/src/HASS.Agent.NET10/Tray/MainForm.cs
+++ b/src/HASS.Agent.NET10/Tray/MainForm.cs
@@ -1078,7 +1078,10 @@ internal sealed class MainForm : Form
             CustomSensorTypes.ProcessRunning,
             CustomSensorTypes.ServiceStatus,
             CustomSensorTypes.DiskFree,
-            CustomSensorTypes.BuiltInAttribute
+            CustomSensorTypes.BuiltInAttribute,
+            CustomSensorTypes.Command,
+            CustomSensorTypes.CommandPowerShell,
+            CustomSensorTypes.CommandPwsh
         }
             .Select(t => new KeyValuePair<string, string>(t, S($"SensorType.{t}")))
             .ToArray();
@@ -1097,6 +1100,10 @@ internal sealed class MainForm : Form
         {
             Name = "Parameter", HeaderText = S("Sensors.Parameter"),
             Width = D(170), MinimumWidth = D(80)
+        });
+        _customGrid.Columns.Add(new DataGridViewTextBoxColumn
+        {
+            Name = "Unit", HeaderText = S("Sensors.Unit"), Width = D(60), MinimumWidth = D(45)
         });
         _customGrid.Columns.Add(new DataGridViewTextBoxColumn
         {
@@ -2131,7 +2138,8 @@ internal sealed class MainForm : Form
             sensor.Type,
             sensor.Name,
             SensorPollingProfiles.NormalizeKey(sensor.PollingProfile, SensorPollingProfile.Normal),
-            sensor.Parameter);
+            sensor.Parameter,
+            sensor.Unit);
         _customGrid.Rows[rowIndex].Tag = sensor.Id;
         return rowIndex;
     }
@@ -2214,6 +2222,7 @@ internal sealed class MainForm : Form
         var type = Convert.ToString(row.Cells["Type"].Value) ?? CustomSensorTypes.ProcessRunning;
         var name = Convert.ToString(row.Cells["Name"].Value) ?? string.Empty;
         var parameter = Convert.ToString(row.Cells["Parameter"].Value) ?? string.Empty;
+        var unit = Convert.ToString(row.Cells["Unit"].Value) ?? string.Empty;
         var pollingProfile = Convert.ToString(row.Cells["Profile"].Value) ?? SensorPollingProfiles.ToKey(SensorPollingProfile.Normal);
         return new CustomSensorDefinition
         {
@@ -2222,6 +2231,7 @@ internal sealed class MainForm : Form
             Type = type,
             Name = string.IsNullOrWhiteSpace(name) ? type : name.Trim(),
             Parameter = parameter.Trim(),
+            Unit = unit.Trim(),
             PollingProfile = SensorPollingProfiles.NormalizeKey(pollingProfile, SensorPollingProfile.Normal),
             Service = forceEnabled || Convert.ToBoolean(row.Cells["Service"].Value ?? false),
             TrayApp = forceEnabled || Convert.ToBoolean(row.Cells["TrayApp"].Value ?? false)
@@ -2366,6 +2376,7 @@ internal sealed class MainForm : Form
             if (string.IsNullOrWhiteSpace(param)) continue;
             var type = Convert.ToString(row.Cells["Type"].Value) ?? CustomSensorTypes.ProcessRunning;
             var name = Convert.ToString(row.Cells["Name"].Value) ?? string.Empty;
+            var unit = Convert.ToString(row.Cells["Unit"].Value) ?? string.Empty;
             var pollingProfile = Convert.ToString(row.Cells["Profile"].Value) ?? SensorPollingProfiles.ToKey(SensorPollingProfile.Normal);
             sensors.Add(new CustomSensorDefinition
             {
@@ -2374,6 +2385,7 @@ internal sealed class MainForm : Form
                 Type = type,
                 Name = string.IsNullOrWhiteSpace(name) ? type : name.Trim(),
                 Parameter = param.Trim(),
+                Unit = unit.Trim(),
                 PollingProfile = SensorPollingProfiles.NormalizeKey(pollingProfile, SensorPollingProfile.Normal),
                 Service = Convert.ToBoolean(row.Cells["Service"].Value ?? false),
                 TrayApp = Convert.ToBoolean(row.Cells["TrayApp"].Value ?? false)


### PR DESCRIPTION
Implements **command sensors** (requested in #10): a custom sensor whose value is the output of a program or PowerShell script — e.g. GPU temperature via `nvidia-smi`.

## What's new
- Three sensor types: **command** (runs a program directly), **command_powershell**, **command_pwsh**. Reuses `SplitProcessCommand` and the PowerShell start-info pattern from the 10.6.0 custom command buttons.
- `ReadCommandSensorValue`: stdout capture with a bounded ~10 s wait (kills a hung process), takes the **first non-empty line**, publishes a **number** when the output is numeric, caps to 255 chars.
- Optional per-sensor **Unit**: advertised in discovery and marks the sensor as a numeric `measurement` (unit + long-term statistics/graphs in Home Assistant). The descriptor's unit/state_class were generalized (`disk_free` keeps its GiB default).
- Tray grid: three new Type combo entries + a **Unit** column; save/load wired.
- Discovery icons, EN/HU strings, README (Custom Sensors doc section + changelog).

## Notes
- **No Home Assistant integration change** — the integration renders custom sensors generically from `{id, value}` and already reads `unit`/`state_class`.
- Version bumped to **10.6.0-beta.3** (folded into the custom-command line, not a separate minor).

Example:
```
Type: Command (program)
Parameter: nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits
Unit: °C
→ 50 °C (numeric, graphable)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-based custom sensors for programs, PowerShell, PowerShell 7, and script files.
  * Command sensors capture output, support numeric values and optional units, and enforce a 10-second timeout.
  * Added configurable units for custom sensors, with improved measurement classification and icons.
  * Added configuration support for creating, editing, testing, and saving command sensors.

* **Documentation**
  * Expanded setup guidance and localization for command sensors, sensor units, and supported command types.

* **Release**
  * Updated the application to version 10.6.0-beta.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->