### PR TITLE
Address command-sensor review feedback (10.6.0-beta.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Custom sensors are parameterized sensors you can add multiple times with differe
 - **Type** - what kind of sensor it is
 - **Name** - the entity name in Home Assistant
 - **Parameter** - what to monitor (depends on type)
+- **Unit** - optional unit of measurement shown in Home Assistant (marks the sensor as a numeric `measurement`)
 - **Profile** - polling interval (fast / normal / hourly / startup)
 
 <p align="center"><img src="docs/images/ui-sensors-custom.png" width="900" alt="Custom sensors tab"></p>

--- a/src/HASS.Agent.NET10/Localization/Strings.en.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.en.cs
@@ -194,7 +194,7 @@ internal static partial class Strings
             ["Sensors.CustomRemove"] = "Remove custom",
             ["Sensors.MultiValueTooltip"] = "This sensor has additional values. Click to add a custom sensor from an attribute.",
             ["Sensors.AttributeSensorName"] = "{0}: {1}",
-            ["Sensors.CustomHelp"] = "Parameters: process_running = process name, service_status = Windows service name, disk_free = drive letter/path. Command types = the program/command line (e.g. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); the first line of its output becomes the value — use the Normal/Hourly profile. For built-in attributes, click + on a built-in sensor; every available attribute is added with [0] for list values.",
+            ["Sensors.CustomHelp"] = "Parameters: process_running = process name, service_status = Windows service name, disk_free = drive letter/path. Command types = the program/command line (e.g. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); the first non-empty line of its output becomes the value — use the Normal/Hourly profile. For built-in attributes, click + on a built-in sensor; every available attribute is added with [0] for list values.",
             ["Sensors.ValueLoading"] = "reading...",
             ["Sensors.ValueNotTested"] = "not tested",
             ["Sensors.ValueMissingParameter"] = "missing parameter",

--- a/src/HASS.Agent.NET10/Localization/Strings.hu.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.hu.cs
@@ -194,7 +194,7 @@ internal static partial class Strings
             ["Sensors.CustomRemove"] = "Egyedi törlés",
             ["Sensors.MultiValueTooltip"] = "Ez a szenzor több értéket is ad. Kattints egy attribútum alapú egyedi szenzor hozzáadásához.",
             ["Sensors.AttributeSensorName"] = "{0}: {1}",
-            ["Sensors.CustomHelp"] = "Paraméterek: process_running = processz név, service_status = Windows service név, disk_free = meghajtó betűjel/útvonal. Parancs típusok = a program/parancssor (pl. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); a kimenet első sora lesz az érték — használd a Normál/Óránkénti profilt. Beépített attribútumhoz kattints a + ikonra; minden elérhető attribútum bekerül, listáknál [0] indexszel.",
+            ["Sensors.CustomHelp"] = "Paraméterek: process_running = processz név, service_status = Windows service név, disk_free = meghajtó betűjel/útvonal. Parancs típusok = a program/parancssor (pl. nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits); a kimenet első nem-üres sora lesz az érték — használd a Normál/Óránkénti profilt. Beépített attribútumhoz kattints a + ikonra; minden elérhető attribútum bekerül, listáknál [0] indexszel.",
             ["Sensors.ValueLoading"] = "olvasás...",
             ["Sensors.ValueNotTested"] = "nincs tesztelve",
             ["Sensors.ValueMissingParameter"] = "hiányzó paraméter",

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -884,14 +884,34 @@ internal sealed class SystemMetricsService : IDisposable
     {
         var previousById = previousStates.ToDictionary(state => state.Id, StringComparer.OrdinalIgnoreCase);
 
-        return sensors
+        var active = sensors
             .Where(sensor => sensor.Enabled && (serviceRole ? sensor.Service : sensor.TrayApp))
+            .ToList();
+
+        bool IsDue(CustomSensorDefinition sensor) =>
+            dueProfiles.Contains(sensor.EffectivePollingProfile) || !previousById.ContainsKey(sensor.Id);
+
+        // Command sensors can each block up to the command timeout, so run the due ones
+        // concurrently — a slow or hung command then delays the snapshot by roughly one
+        // timeout instead of the sum of all of them.
+        var commandTasks = active
+            .Where(sensor => sensor.IsAnyCommand && IsDue(sensor))
+            .ToDictionary(
+                sensor => sensor.Id,
+                sensor => Task.Run(() => ReadCustomSensor(sensor, attributes)),
+                StringComparer.OrdinalIgnoreCase);
+
+        return active
             .Select(sensor =>
             {
-                var profile = sensor.EffectivePollingProfile;
-                return dueProfiles.Contains(profile) || !previousById.TryGetValue(sensor.Id, out var previous)
+                if (commandTasks.TryGetValue(sensor.Id, out var task))
+                {
+                    return task.GetAwaiter().GetResult();
+                }
+
+                return IsDue(sensor)
                     ? ReadCustomSensor(sensor, attributes)
-                    : previous;
+                    : previousById[sensor.Id];
             })
             .ToList();
     }
@@ -987,8 +1007,11 @@ internal sealed class SystemMetricsService : IDisposable
             return null;
         }
 
-        // Read stdout before waiting so a large output cannot fill the pipe and deadlock.
+        // Drain both pipes before waiting: if a command writes a lot to stdout or stderr,
+        // an unread pipe fills up and blocks the child, which would then hit the timeout
+        // and discard otherwise-valid output.
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
         if (!process.WaitForExit(CommandSensorTimeoutMs))
         {
             try
@@ -1004,6 +1027,7 @@ internal sealed class SystemMetricsService : IDisposable
         }
 
         var output = stdoutTask.GetAwaiter().GetResult();
+        _ = stderrTask.GetAwaiter().GetResult();
         return ExtractFirstLine(output);
     }
 
@@ -1029,7 +1053,11 @@ internal sealed class SystemMetricsService : IDisposable
                 return longValue;
             }
 
-            if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue))
+            // Guard against NaN / Infinity: double.TryParse accepts "NaN"/"Infinity",
+            // which System.Text.Json cannot serialize by default — keep those as strings.
+            if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue)
+                && !double.IsNaN(doubleValue)
+                && !double.IsInfinity(doubleValue))
             {
                 return doubleValue;
             }


### PR DESCRIPTION
Follow-up to #11 addressing the CodeRabbit review. Fixes the genuine issues, skips one for consistency.

## Fixed
- **stderr drain** — `ReadCommandSensorValue` set `RedirectStandardError=true` but never read it; a command flooding stderr could fill the pipe, block the child, hit the timeout and discard valid stdout. Now stderr is drained concurrently with stdout.
- **NaN/Infinity guard** — `double.TryParse` accepts `NaN`/`Infinity`, which `System.Text.Json` can't serialize by default. Those now stay strings.
- **Concurrent command reads** — due command sensors ran serially, so multiple slow/hung commands added up (N × timeout). They now run concurrently — worst case ≈ one timeout.
- **Docs** — help text says 'first non-empty line'; README lists the optional **Unit** field.

## Skipped (with reason)
- *Pass PowerShell args via `ArgumentList`* — the custom command **buttons** use the same `-Command "..."` string pattern; changing only the sensor path would be inconsistent, and typical commands don't contain quotes. Worth a separate cleanup across both paths.

Version stays **10.6.0-beta.3** (re-cut with these fixes). No Home Assistant integration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)