### PR TITLE
Release 10.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.0--beta.3-orange)
+![Version](https://img.shields.io/badge/version-10.6.0-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -12,6 +12,8 @@
 A modern Windows companion app for Home Assistant.
 
 🌐 **[Website & screenshots](https://v1k70rk4.github.io/HASS.Agent.NET10/)**
+
+> ⭐ **Enjoying HASS.Agent?** Please star this repo — and the [Home Assistant integration](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration) too. It helps others find the project and keeps it going!
 
 This fork refreshes the classic HASS.Agent idea into **HASS.Agent .NET10**, a lightweight .NET 10 client built for current Windows desktops. The original client was a .NET 6-era application; this version focuses on a smaller, cleaner runtime, Home Assistant integration via MQTT or WebSocket API, Windows 11-friendly UX, and a split tray app/system service model.
 
@@ -54,6 +56,15 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.0
+
+Stable release of the custom commands & command sensors line.
+
+- **Custom command buttons** — run your own programs or PowerShell/pwsh scripts from Home Assistant. You define what runs; Home Assistant only triggers a command by its id (it can't send arbitrary code). Also handles a full command line typed into the command field (e.g. `taskkill /F /IM app.exe /T`).
+- **Command sensors** — a custom sensor whose value is the output of a program or PowerShell script (e.g. GPU temperature via `nvidia-smi`), with an optional **unit** that makes it a numeric `measurement` (graphs & statistics in Home Assistant).
+- **Fixed in-app updates** (from the About page) aborting: the installer closes the running app with `taskkill /… /T`, which also killed the installer when it was launched as a child of the app. It now runs detached, so it survives, installs, and relaunches the app. Updating from Home Assistant was unaffected.
+- **Update the Home Assistant integration too** — it's now in the **HACS default store**, so no custom repository is needed (search "HASS.Agent").
 
 ### 10.6.0-beta.3
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.0-beta.3"
+#define MyAppVersion "10.6.0"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.0-beta.3</Version>
+    <Version>10.6.0</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Localization/Strings.en.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.en.cs
@@ -227,7 +227,7 @@ internal static partial class Strings
             ["About.DownloadingUpdate"] = "Downloading...",
             ["About.NoUpdates"] = "You are up to date. Latest release: {0}.",
             ["About.UpdateAvailable"] = "A newer release is available: {0}\n\nInstalled version: {1}\n\nDownload it now?",
-            ["About.UpdateDownloaded"] = "Update downloaded to:\n{0}\n\nOpen it now?",
+            ["About.UpdateDownloaded"] = "Update downloaded to:\n{0}\n\nOpen it now? The app will close during the install and reopen when it finishes.",
             ["About.UpdateCheckFailed"] = "Unable to read the latest release from GitHub.",
             ["About.UpdateError"] = "Update check failed: {0}",
 

--- a/src/HASS.Agent.NET10/Localization/Strings.hu.cs
+++ b/src/HASS.Agent.NET10/Localization/Strings.hu.cs
@@ -227,7 +227,7 @@ internal static partial class Strings
             ["About.DownloadingUpdate"] = "Letöltés...",
             ["About.NoUpdates"] = "Naprakész verziót használsz. Legfrissebb release: {0}.",
             ["About.UpdateAvailable"] = "Elérhető egy újabb release: {0}\n\nTelepített verzió: {1}\n\nLetöltöd most?",
-            ["About.UpdateDownloaded"] = "A frissítés letöltve ide:\n{0}\n\nMegnyitod most?",
+            ["About.UpdateDownloaded"] = "A frissítés letöltve ide:\n{0}\n\nMegnyitod most? Az app a telepítés alatt bezárul, majd a végén újraindul.",
             ["About.UpdateCheckFailed"] = "Nem sikerült lekérni a legfrissebb GitHub release-t.",
             ["About.UpdateError"] = "Frissítés ellenőrzési hiba: {0}",
 

--- a/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
+++ b/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+using HASS.Agent.Companion.Logging;
+
+namespace HASS.Agent.Companion.Runtime;
+
+/// <summary>
+/// Launches the update installer detached from the tray app's process tree.
+///
+/// The installer closes the running app with <c>taskkill /IM HASS.Agent.NET10.exe /T /F</c>
+/// (see the installer script). The <c>/T</c> kills the whole process tree, so if the
+/// installer were started as a direct child of the tray app it would kill itself when it
+/// closes the app. Running it from a one-shot scheduled task (via a small batch) gives it
+/// no parent link to the tray app, so it survives — exactly like the service-role and
+/// relaunch-watchdog paths already do.
+///
+/// The installer runs its normal (visible) wizard — not silently — so the user can see
+/// what is happening, and it relaunches the app itself when it finishes (its own
+/// post-install step, which runs because we do not pass /SILENTUPDATE).
+/// </summary>
+internal static class DetachedUpdateLauncher
+{
+    private const string TaskName = "HASSAgentNet10AppUpdate";
+
+    public static bool TryLaunchInstaller(string installerPath, FileLog log)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(installerPath);
+            if (string.IsNullOrEmpty(directory))
+            {
+                return false;
+            }
+
+            // A tiny batch launches the installer detached; `start` returns immediately so
+            // the brief console window closes on its own and the installer's wizard shows.
+            var batchPath = Path.Combine(directory, "hassagent-update.cmd");
+            File.WriteAllText(
+                batchPath,
+                "@echo off" + Environment.NewLine +
+                $"start \"\" \"{installerPath}\"" + Environment.NewLine);
+
+            RunSchtasks($"/delete /tn \"{TaskName}\" /f", log, ignoreErrors: true);
+            if (!RunSchtasks($"/create /tn \"{TaskName}\" /tr \"\\\"{batchPath}\\\"\" /sc once /st 00:00 /f", log))
+            {
+                return false;
+            }
+
+            if (!RunSchtasks($"/run /tn \"{TaskName}\"", log))
+            {
+                return false;
+            }
+
+            log.Info("Update installer launched via detached scheduled task.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.Warning($"Detached installer launch failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool RunSchtasks(string arguments, FileLog log, bool ignoreErrors = false)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "schtasks.exe",
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            });
+
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit(10_000);
+            if (process.ExitCode != 0)
+            {
+                if (!ignoreErrors)
+                {
+                    log.Warning($"schtasks {arguments} exited with code {process.ExitCode}: {process.StandardError.ReadToEnd().Trim()}");
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ignoreErrors)
+        {
+            log.Debug($"schtasks {arguments} failed (ignored): {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/HASS.Agent.NET10/Tray/MainForm.cs
+++ b/src/HASS.Agent.NET10/Tray/MainForm.cs
@@ -2297,7 +2297,13 @@ internal sealed class MainForm : Form
                 MessageBoxIcon.Information);
             if (open == DialogResult.Yes)
             {
-                Process.Start(new ProcessStartInfo(targetPath) { UseShellExecute = true });
+                // Launch detached from this process tree: the installer closes the running
+                // app with `taskkill /IM ... /T`, which would also kill the installer if it
+                // were our child. It self-elevates (UAC) and relaunches the app when done.
+                if (!DetachedUpdateLauncher.TryLaunchInstaller(targetPath, _log))
+                {
+                    Process.Start(new ProcessStartInfo(targetPath) { UseShellExecute = true, Verb = "runas" });
+                }
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Stable release of the custom commands & command sensors line, plus an in-app update fix.

## Highlights
- **Custom command buttons** — run your own programs or PowerShell/pwsh scripts from Home Assistant (you define what runs; HA only triggers by id). Handles a full command line typed into the command field too.
- **Command sensors** — a custom sensor whose value is the output of a program or PowerShell script (e.g. GPU temp via `nvidia-smi`), with an optional **unit** → numeric `measurement`.
- **Fix: in-app updates aborting** — the installer closes the app with `taskkill /… /T`, which killed the installer when it was a child of the app. It now launches **detached** (one-shot scheduled task), so it survives, installs and relaunches. HA-triggered updates were unaffected.
- **Docs** — star call-to-action, HACS default integration note, 10.6.0 changelog.

Closes the work from #9 and #10. No Home Assistant integration change required (it's in the HACS default store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application to stable version 10.6.0.
  - Added improved update installation handling, including automatic app closure and restart after installation.
  - Added a fallback path for installations requiring elevated permissions.

- **Bug Fixes**
  - Improved reliability when launching downloaded updates from the tray application.

- **Documentation**
  - Updated release notes with 10.6.0 features, fixes, and availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->