### PR TITLE
Release 10.6.1: fix sensor-loop NRE and update-check 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.0-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.1-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -56,6 +56,11 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.1
+
+- Fixed a **`NullReferenceException` in the sensor loop** that could make the device go (and stay) **unavailable** in Home Assistant, typically after startup or resume from sleep. A transient network adapter with a null name/description (common with VPN/virtual adapters mid-initialization) threw inside the network reads, aborting every sensor cycle. The network reads are now null-safe and fault-isolated.
+- Fixed **GitHub update-check `403 (rate limit exceeded)`**: the update state was queried on every reconnect, which — with frequent reconnects and several devices behind one IP — exhausted the unauthenticated GitHub API limit. The result is now cached/throttled (at most once per hour outside the 6-hour poll).
 
 ### 10.6.0
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.0"
+#define MyAppVersion "10.6.1"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.0</Version>
+    <Version>10.6.1</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -21,6 +21,14 @@ internal sealed class MqttCompanionService : IDisposable
 {
     private static readonly TimeSpan UpdateCheckInterval = TimeSpan.FromHours(6);
 
+    // The connect handler publishes the update state on every (re)connect. The unauthenticated
+    // GitHub API allows only 60 requests/hour per IP, so with frequent reconnects (and several
+    // devices behind one IP) that hits a 403 rate limit. Reuse a cached result within this
+    // window and only actually query GitHub once it has elapsed.
+    private static readonly TimeSpan UpdateCheckThrottle = TimeSpan.FromHours(1);
+    private DateTimeOffset _lastUpdateCheck = DateTimeOffset.MinValue;
+    private AppUpdateState? _lastUpdateState;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -1276,19 +1284,28 @@ internal sealed class MqttCompanionService : IDisposable
         while (!cancellationToken.IsCancellationRequested)
         {
             await Task.Delay(UpdateCheckInterval, cancellationToken);
-            await PublishUpdateStateAsync();
+            await PublishUpdateStateAsync(forceCheck: true);
         }
     }
 
-    private async Task PublishUpdateStateAsync()
+    private async Task PublishUpdateStateAsync(bool forceCheck = false)
     {
-        var update = await AppUpdateService.CheckAsync(_settings.SoftwareVersion, _settings.BetaUpdatesEnabled);
-        if (!string.IsNullOrWhiteSpace(update.Error))
+        var now = DateTimeOffset.UtcNow;
+
+        // Only hit the GitHub API when forced (the 6-hour loop) or once the throttle window
+        // has elapsed; otherwise re-publish the cached result. This keeps frequent reconnects
+        // from exhausting the unauthenticated GitHub rate limit (403).
+        if (forceCheck || _lastUpdateState is null || now - _lastUpdateCheck >= UpdateCheckThrottle)
         {
-            _log.Warning($"Unable to publish update state: {update.Error}");
+            _lastUpdateState = await AppUpdateService.CheckAsync(_settings.SoftwareVersion, _settings.BetaUpdatesEnabled);
+            _lastUpdateCheck = now;
+            if (!string.IsNullOrWhiteSpace(_lastUpdateState.Error))
+            {
+                _log.Warning($"Unable to publish update state: {_lastUpdateState.Error}");
+            }
         }
 
-        await PublishJsonAsync(UpdateStateTopic, update, retain: true);
+        await PublishJsonAsync(UpdateStateTopic, _lastUpdateState, retain: true);
     }
 
     private async Task PublishHomeAssistantUpdateDiscoveryAsync()

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -28,6 +28,7 @@ internal sealed class MqttCompanionService : IDisposable
     private static readonly TimeSpan UpdateCheckThrottle = TimeSpan.FromHours(1);
     private DateTimeOffset _lastUpdateCheck = DateTimeOffset.MinValue;
     private AppUpdateState? _lastUpdateState;
+    private bool _lastUpdateBeta;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -1295,9 +1296,13 @@ internal sealed class MqttCompanionService : IDisposable
         // Only hit the GitHub API when forced (the 6-hour loop) or once the throttle window
         // has elapsed; otherwise re-publish the cached result. This keeps frequent reconnects
         // from exhausting the unauthenticated GitHub rate limit (403).
-        if (forceCheck || _lastUpdateState is null || now - _lastUpdateCheck >= UpdateCheckThrottle)
+        if (forceCheck
+            || _lastUpdateState is null
+            || _lastUpdateBeta != _settings.BetaUpdatesEnabled
+            || now - _lastUpdateCheck >= UpdateCheckThrottle)
         {
             _lastUpdateState = await AppUpdateService.CheckAsync(_settings.SoftwareVersion, _settings.BetaUpdatesEnabled);
+            _lastUpdateBeta = _settings.BetaUpdatesEnabled;
             _lastUpdateCheck = now;
             if (!string.IsNullOrWhiteSpace(_lastUpdateState.Error))
             {

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -304,17 +304,46 @@ internal sealed class SystemMetricsService : IDisposable
 
     private static IReadOnlyList<NetworkAddressInfo> ReadNetworkAddresses()
     {
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(adapter =>
-                adapter.OperationalStatus == OperationalStatus.Up &&
-                adapter.NetworkInterfaceType != NetworkInterfaceType.Loopback)
-            .SelectMany(adapter => adapter.GetIPProperties().UnicastAddresses
-                .Where(address =>
-                    address.Address.AddressFamily == AddressFamily.InterNetwork &&
-                    !IPAddress.IsLoopback(address.Address) &&
-                    !address.Address.ToString().StartsWith("169.254.", StringComparison.Ordinal))
-                .Select(address => new NetworkAddressInfo(adapter.Name, adapter.Description, address.Address.ToString())))
-            .ToList();
+        var result = new List<NetworkAddressInfo>();
+        try
+        {
+            foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (adapter.OperationalStatus != OperationalStatus.Up ||
+                    adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    // GetIPProperties() can throw on an adapter that is mid-reinitialization
+                    // after startup/resume; skip it instead of failing the whole read.
+                    foreach (var address in adapter.GetIPProperties().UnicastAddresses)
+                    {
+                        if (address.Address.AddressFamily == AddressFamily.InterNetwork &&
+                            !IPAddress.IsLoopback(address.Address) &&
+                            !address.Address.ToString().StartsWith("169.254.", StringComparison.Ordinal))
+                        {
+                            result.Add(new NetworkAddressInfo(
+                                adapter.Name ?? string.Empty,
+                                adapter.Description ?? string.Empty,
+                                address.Address.ToString()));
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore this adapter and keep going.
+                }
+            }
+        }
+        catch
+        {
+            // Enumerating interfaces failed entirely — return whatever was collected.
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -367,11 +396,24 @@ internal sealed class SystemMetricsService : IDisposable
     private static bool ReadVpnConnected()
     {
         string[] vpnHints = ["vpn", "wireguard", "tailscale", "zerotier", "tap", "tun", "openvpn", "nord", "proton", "surfshark"];
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(adapter => adapter.OperationalStatus == OperationalStatus.Up)
-            .Any(adapter =>
-                vpnHints.Any(hint => adapter.Name.Contains(hint, StringComparison.OrdinalIgnoreCase)) ||
-                vpnHints.Any(hint => adapter.Description.Contains(hint, StringComparison.OrdinalIgnoreCase)));
+        try
+        {
+            // Right after startup/resume an adapter can be "Up" but still have a null
+            // Name/Description while the network stack re-initializes — guard against it.
+            return NetworkInterface.GetAllNetworkInterfaces()
+                .Where(adapter => adapter.OperationalStatus == OperationalStatus.Up)
+                .Any(adapter =>
+                {
+                    var name = adapter.Name ?? string.Empty;
+                    var description = adapter.Description ?? string.Empty;
+                    return vpnHints.Any(hint => name.Contains(hint, StringComparison.OrdinalIgnoreCase)) ||
+                           vpnHints.Any(hint => description.Contains(hint, StringComparison.OrdinalIgnoreCase));
+                });
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static (string Ssid, int? Signal) ReadWifiStatus()

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -309,16 +309,17 @@ internal sealed class SystemMetricsService : IDisposable
         {
             foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces())
             {
-                if (adapter.OperationalStatus != OperationalStatus.Up ||
-                    adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback)
-                {
-                    continue;
-                }
-
                 try
                 {
-                    // GetIPProperties() can throw on an adapter that is mid-reinitialization
-                    // after startup/resume; skip it instead of failing the whole read.
+                    // Any adapter property (status, GetIPProperties, …) can throw on an adapter
+                    // that is mid-reinitialization after startup/resume; skip just that adapter
+                    // instead of failing the whole read.
+                    if (adapter.OperationalStatus != OperationalStatus.Up ||
+                        adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    {
+                        continue;
+                    }
+
                     foreach (var address in adapter.GetIPProperties().UnicastAddresses)
                     {
                         if (address.Address.AddressFamily == AddressFamily.InterNetwork &&
@@ -396,24 +397,43 @@ internal sealed class SystemMetricsService : IDisposable
     private static bool ReadVpnConnected()
     {
         string[] vpnHints = ["vpn", "wireguard", "tailscale", "zerotier", "tap", "tun", "openvpn", "nord", "proton", "surfshark"];
+        NetworkInterface[] adapters;
         try
         {
-            // Right after startup/resume an adapter can be "Up" but still have a null
-            // Name/Description while the network stack re-initializes — guard against it.
-            return NetworkInterface.GetAllNetworkInterfaces()
-                .Where(adapter => adapter.OperationalStatus == OperationalStatus.Up)
-                .Any(adapter =>
-                {
-                    var name = adapter.Name ?? string.Empty;
-                    var description = adapter.Description ?? string.Empty;
-                    return vpnHints.Any(hint => name.Contains(hint, StringComparison.OrdinalIgnoreCase)) ||
-                           vpnHints.Any(hint => description.Contains(hint, StringComparison.OrdinalIgnoreCase));
-                });
+            adapters = NetworkInterface.GetAllNetworkInterfaces();
         }
         catch
         {
             return false;
         }
+
+        foreach (var adapter in adapters)
+        {
+            try
+            {
+                // Right after startup/resume an adapter can be "Up" but still have a null
+                // Name/Description while the network stack re-initializes. Guard each adapter
+                // on its own so one flaky adapter doesn't hide a VPN on a later one.
+                if (adapter.OperationalStatus != OperationalStatus.Up)
+                {
+                    continue;
+                }
+
+                var name = adapter.Name ?? string.Empty;
+                var description = adapter.Description ?? string.Empty;
+                if (vpnHints.Any(hint => name.Contains(hint, StringComparison.OrdinalIgnoreCase)) ||
+                    vpnHints.Any(hint => description.Contains(hint, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Skip this adapter and keep checking the rest.
+            }
+        }
+
+        return false;
     }
 
     private static (string Ssid, int? Signal) ReadWifiStatus()


### PR DESCRIPTION
Fixes the issues reported in [Integration #5](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration/issues/5) (device going unavailable, repeated `NullReferenceException`, GitHub 403).

## Root cause
Right after startup / resume from sleep, a transient network adapter can be `Up` but still have a **null Name/Description** (common with VPN / Hyper-V / WSL / virtual adapters mid-initialization). `ReadVpnConnected` (`adapter.Name.Contains(...)`) and `ReadNetworkAddresses` (`GetIPProperties()`) weren't guarded, so they threw a `NullReferenceException`. That aborted the whole sensor read **before `_lastMessage` was set** — which then forced a full read on **every** cycle, re-hitting the failing adapter every ~10s, so the device never published and stayed **unavailable** in Home Assistant.

## Fixes
- **Network reads null-safe + fault-isolated** — `ReadVpnConnected` and `ReadNetworkAddresses` guard null Name/Description and wrap per-adapter access in try/catch, so a flaky adapter is skipped instead of crashing the cycle.
- **Update-check 403** — the update state was queried on every reconnect; the unauthenticated GitHub API allows only 60 req/hour/IP, so frequent reconnects (× several devices behind one IP) hit `403 (rate limit exceeded)`. The result is now cached/throttled (≥ 1h between GitHub calls, outside the 6h poll).

Not machine-specific — it's our missing guards against a legitimate (if uncommon) Windows adapter state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network and VPN status reporting when individual adapters are unavailable or provide incomplete information.
  * Prevented sensor/status monitoring from failing entirely due to isolated network-read errors.
  * Reduced unnecessary update checks while continuing to provide current update notifications.

* **Documentation**
  * Added release notes covering monitoring reliability and update-check improvements.

* **Chores**
  * Updated the application and installer version to 10.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->