### PR TITLE
Release 10.6.2-beta.1: fault-isolate and log each metric read

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.1-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.2--beta.1-orange)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -56,6 +56,10 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.2-beta.1
+
+- **Diagnostic / resilience build** for a lingering `NullReferenceException` in the sensor loop (reported in #15) that 10.6.1's network-read fix didn't fully cover. Each individual metric read is now **fault-isolated**: if one read throws, it falls back to the previous value instead of aborting the whole cycle (so the device stays online), and the log names the **exact** read that failed — so the remaining culprit can be pinpointed instead of guessed at.
 
 ### 10.6.1
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.1"
+#define MyAppVersion "10.6.2-beta.1"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.1</Version>
+    <Version>10.6.2-beta.1</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -75,30 +75,30 @@ internal sealed class SystemMetricsService : IDisposable
         var updateHourly = profiles.Contains(SensorPollingProfile.Hourly);
         var updateStartup = profiles.Contains(SensorPollingProfile.Startup);
 
-        var memory = updateFast ? ReadMemory() : (UsagePercent: previous!.MemoryUsage, AvailableMb: previous.MemoryAvailableMb);
-        var activeWindow = updateFast && _includeInteractiveMetrics ? ReadActiveWindow() : (Title: previous?.ActiveWindow ?? string.Empty, ProcessName: previous?.ActiveProcess ?? string.Empty);
-        var sessionLocked = updateFast && _includeInteractiveMetrics ? ReadSessionLocked() : previous?.SessionLocked;
+        var memory = updateFast ? Safe(ReadMemory, (UsagePercent: previous?.MemoryUsage ?? 0, AvailableMb: previous?.MemoryAvailableMb ?? 0)) : (UsagePercent: previous!.MemoryUsage, AvailableMb: previous.MemoryAvailableMb);
+        var activeWindow = updateFast && _includeInteractiveMetrics ? Safe(ReadActiveWindow, (Title: previous?.ActiveWindow ?? string.Empty, ProcessName: previous?.ActiveProcess ?? string.Empty)) : (Title: previous?.ActiveWindow ?? string.Empty, ProcessName: previous?.ActiveProcess ?? string.Empty);
+        var sessionLocked = updateFast && _includeInteractiveMetrics ? Safe(ReadSessionLocked, previous?.SessionLocked) : previous?.SessionLocked;
 
-        var drive = updateNormal ? ReadSystemDrive() : (FreePercent: previous!.SystemDriveFreePercent, FreeGb: previous.SystemDriveFreeGb);
-        var power = updateNormal ? ReadPowerStatus() : (BatteryLevel: previous!.BatteryLevel, Status: previous.PowerStatus, TimeRemainingSeconds: previous.BatteryTimeRemaining);
-        var session = updateNormal ? ReadSessionStatus() : (State: previous!.SessionState, User: previous.LoggedInUser);
-        var wifi = updateNormal ? ReadWifiStatus() : (Ssid: previous!.WifiSsid, Signal: previous.WifiSignal);
-        var sessions = updateNormal ? ReadSessionCounts() : (LoggedInUsers: previous!.LoggedInUsers, RdpSessions: previous.RdpSessions);
+        var drive = updateNormal ? Safe(ReadSystemDrive, (FreePercent: previous?.SystemDriveFreePercent ?? 0, FreeGb: previous?.SystemDriveFreeGb ?? 0)) : (FreePercent: previous!.SystemDriveFreePercent, FreeGb: previous.SystemDriveFreeGb);
+        var power = updateNormal ? Safe(ReadPowerStatus, (BatteryLevel: previous?.BatteryLevel, Status: previous?.PowerStatus ?? "unknown", TimeRemainingSeconds: previous?.BatteryTimeRemaining)) : (BatteryLevel: previous!.BatteryLevel, Status: previous.PowerStatus, TimeRemainingSeconds: previous.BatteryTimeRemaining);
+        var session = updateNormal ? Safe(ReadSessionStatus, (State: previous?.SessionState ?? "none", User: previous?.LoggedInUser ?? string.Empty)) : (State: previous!.SessionState, User: previous.LoggedInUser);
+        var wifi = updateNormal ? Safe(ReadWifiStatus, (Ssid: previous?.WifiSsid ?? string.Empty, Signal: previous?.WifiSignal)) : (Ssid: previous!.WifiSsid, Signal: previous.WifiSignal);
+        var sessions = updateNormal ? Safe(ReadSessionCounts, (LoggedInUsers: previous?.LoggedInUsers ?? 0, RdpSessions: previous?.RdpSessions ?? 0)) : (LoggedInUsers: previous!.LoggedInUsers, RdpSessions: previous.RdpSessions);
 
         if (updateNormal)
         {
-            _lastNetworkAddresses = ReadNetworkAddresses();
-            _lastDisplays = _includeInteractiveMetrics ? ReadDisplaysSafe() : [];
+            _lastNetworkAddresses = Safe(ReadNetworkAddresses, _lastNetworkAddresses);
+            _lastDisplays = _includeInteractiveMetrics ? Safe(ReadDisplaysSafe, _lastDisplays) : [];
         }
 
         if (updateHourly)
         {
-            _lastRecentErrors = ReadRecentEventLogErrors(TimeSpan.FromHours(1));
+            _lastRecentErrors = Safe(() => ReadRecentEventLogErrors(TimeSpan.FromHours(1)), _lastRecentErrors);
         }
 
         if (updateStartup)
         {
-            _lastShutdown = ReadLastShutdownInfo();
+            _lastShutdown = Safe(ReadLastShutdownInfo, _lastShutdown);
         }
 
         var attributes = BuildAttributes(_lastNetworkAddresses, _lastDisplays, _lastRecentErrors, _lastShutdown);

--- a/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
+++ b/src/HASS.Agent.NET10/SystemStatus/SystemMetricsService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -28,6 +29,7 @@ internal sealed class SystemMetricsService : IDisposable
     };
 
     private readonly object _cpuLock = new();
+    private readonly FileLog _log;
     private readonly AudioEndpointService? _audioEndpointService;
     private readonly MonitorPowerStateService? _monitorPowerStateService;
     private readonly bool _includeInteractiveMetrics;
@@ -50,6 +52,7 @@ internal sealed class SystemMetricsService : IDisposable
     {
         // The audio service is owned by the caller (it pushes change events), so
         // it is injected rather than created/disposed here.
+        _log = log;
         _audioEndpointService = audioEndpointService;
         _monitorPowerStateService = monitorPowerStateService;
         _includeInteractiveMetrics = includeInteractiveMetrics;
@@ -100,7 +103,7 @@ internal sealed class SystemMetricsService : IDisposable
 
         var attributes = BuildAttributes(_lastNetworkAddresses, _lastDisplays, _lastRecentErrors, _lastShutdown);
         var message = new SystemMetricsMessage(
-            CpuUsage: updateFast ? ReadCpuUsage() : previous!.CpuUsage,
+            CpuUsage: updateFast ? Safe(ReadCpuUsage, previous?.CpuUsage ?? 0) : previous!.CpuUsage,
             MemoryUsage: memory.UsagePercent,
             MemoryAvailableMb: memory.AvailableMb,
             SystemDriveFreePercent: drive.FreePercent,
@@ -109,34 +112,34 @@ internal sealed class SystemMetricsService : IDisposable
             ActiveWindow: updateFast && _includeInteractiveMetrics ? LimitState(activeWindow.Title) : previous!.ActiveWindow,
             ActiveProcess: updateFast && _includeInteractiveMetrics ? LimitState(activeWindow.ProcessName) : previous!.ActiveProcess,
             ForegroundAppTitle: updateFast && _includeInteractiveMetrics ? BuildForegroundAppTitle(activeWindow) : previous!.ForegroundAppTitle,
-            Volume: updateFast ? _audioEndpointService?.GetVolume() : previous!.Volume,
-            Muted: updateFast ? _audioEndpointService?.GetMuted() : previous!.Muted,
-            AudioOutputDevice: updateNormal && _includeInteractiveMetrics ? LimitState(_audioEndpointService?.GetOutputDeviceName() ?? string.Empty) : previous!.AudioOutputDevice,
-            MicrophoneMuted: updateNormal && _includeInteractiveMetrics ? _audioEndpointService?.GetMicrophoneMuted() : previous!.MicrophoneMuted,
+            Volume: updateFast ? Safe(() => _audioEndpointService?.GetVolume(), previous?.Volume) : previous!.Volume,
+            Muted: updateFast ? Safe(() => _audioEndpointService?.GetMuted(), previous?.Muted) : previous!.Muted,
+            AudioOutputDevice: updateNormal && _includeInteractiveMetrics ? Safe(() => LimitState(_audioEndpointService?.GetOutputDeviceName() ?? string.Empty), previous?.AudioOutputDevice ?? string.Empty) : previous!.AudioOutputDevice,
+            MicrophoneMuted: updateNormal && _includeInteractiveMetrics ? Safe(() => _audioEndpointService?.GetMicrophoneMuted(), previous?.MicrophoneMuted) : previous!.MicrophoneMuted,
             BatteryLevel: power.BatteryLevel,
             PowerStatus: power.Status,
             BatteryTimeRemaining: power.TimeRemainingSeconds,
-            MonitorPowerState: updateNormal ? _monitorPowerStateService?.State : previous!.MonitorPowerState,
-            ActiveDisplay: updateNormal && _includeInteractiveMetrics ? FormatDisplayState(_lastDisplays) : previous!.ActiveDisplay,
+            MonitorPowerState: updateNormal ? Safe(() => _monitorPowerStateService?.State, previous?.MonitorPowerState) : previous!.MonitorPowerState,
+            ActiveDisplay: updateNormal && _includeInteractiveMetrics ? Safe(() => FormatDisplayState(_lastDisplays), previous?.ActiveDisplay ?? string.Empty) : previous!.ActiveDisplay,
             NetworkAddress: updateNormal ? _lastNetworkAddresses.FirstOrDefault()?.Address ?? string.Empty : previous!.NetworkAddress,
-            VpnConnected: updateNormal ? ReadVpnConnected() : previous!.VpnConnected,
+            VpnConnected: updateNormal ? Safe(ReadVpnConnected, previous?.VpnConnected ?? false) : previous!.VpnConnected,
             WifiSsid: wifi.Ssid,
             WifiSignal: wifi.Signal,
-            IdleTimeSeconds: updateFast && _includeInteractiveMetrics ? ReadIdleTimeSeconds() : previous!.IdleTimeSeconds,
+            IdleTimeSeconds: updateFast && _includeInteractiveMetrics ? Safe(ReadIdleTimeSeconds, previous?.IdleTimeSeconds) : previous!.IdleTimeSeconds,
             SessionLocked: sessionLocked,
             UserPresent: updateFast && _includeInteractiveMetrics ? session.State == "active" && sessionLocked is false && !string.IsNullOrWhiteSpace(session.User) : previous!.UserPresent,
-            ClipboardTextAvailable: updateFast && _includeInteractiveMetrics ? ReadClipboardTextAvailable() : previous!.ClipboardTextAvailable,
+            ClipboardTextAvailable: updateFast && _includeInteractiveMetrics ? Safe(ReadClipboardTextAvailable, previous?.ClipboardTextAvailable) : previous!.ClipboardTextAvailable,
             SessionState: session.State,
             LoggedInUser: session.User,
             LoggedInUsers: sessions.LoggedInUsers,
             RdpSessions: sessions.RdpSessions,
-            PendingReboot: updateNormal ? ReadPendingReboot() : previous!.PendingReboot,
-            WindowsUpdatePending: updateHourly ? ReadWindowsUpdatePending() : previous!.WindowsUpdatePending,
-            BluetoothEnabled: updateHourly ? ReadBluetoothEnabled() : previous!.BluetoothEnabled,
+            PendingReboot: updateNormal ? Safe(ReadPendingReboot, previous?.PendingReboot ?? false) : previous!.PendingReboot,
+            WindowsUpdatePending: updateHourly ? Safe(ReadWindowsUpdatePending, previous?.WindowsUpdatePending ?? false) : previous!.WindowsUpdatePending,
+            BluetoothEnabled: updateHourly ? Safe(ReadBluetoothEnabled, previous?.BluetoothEnabled ?? false) : previous!.BluetoothEnabled,
             EventLogErrorsRecent: _lastRecentErrors.Count,
             LastShutdownReason: _lastShutdown.Summary,
             BootTime: updateStartup ? DateTimeOffset.Now.AddMilliseconds(-Environment.TickCount64) : previous!.BootTime,
-            CustomSensors: ReadCustomSensors(customSensors ?? [], serviceRole, attributes, profiles, previous?.CustomSensors ?? []),
+            CustomSensors: Safe(() => ReadCustomSensors(customSensors ?? [], serviceRole, attributes, profiles, previous?.CustomSensors ?? []), previous?.CustomSensors ?? []),
             Attributes: attributes,
             UpdatedAt: DateTimeOffset.UtcNow);
 
@@ -146,6 +149,22 @@ internal sealed class SystemMetricsService : IDisposable
 
     public void Dispose()
     {
+    }
+
+    // Isolates a single metric read: on failure it logs which read threw (and the full
+    // exception, so the real method shows even when the Release build inlines the caller)
+    // and returns a fallback, so one bad read can't take the whole sensor cycle offline.
+    private T Safe<T>(Func<T> read, T fallback, [CallerArgumentExpression(nameof(read))] string name = "")
+    {
+        try
+        {
+            return read();
+        }
+        catch (Exception ex)
+        {
+            _log.Warning($"Metric read failed [{name}]: {ex}");
+            return fallback;
+        }
     }
 
     private double ReadCpuUsage()


### PR DESCRIPTION
Diagnostic / resilience beta for the lingering `NullReferenceException` in the sensor loop reported in #15 (10.6.1's network-read fix didn't fully cover it).

## What
Each metric read in the snapshot is wrapped in a `Safe()` helper: on failure it **logs which read threw** (with the full exception — the real method shows through the Release inlining) and **returns a fallback**, so a single bad read no longer aborts the whole cycle. This keeps the device **online** and, crucially, **names the exact culprit** in the log so we can fix the real cause instead of guessing.

Beta so only opt-in (Danger Zone) testers get it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor updates so an individual metric failure no longer interrupts the full sensor cycle.
  * Added fallback handling that preserves the previous value or uses a safe default when a reading fails.
  * Added clearer logging for failed metric reads to support troubleshooting.

* **Release**
  * Updated the application and installer version to **10.6.2-beta.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->