### PR TITLE
Release 10.6.2-beta.3: keep entities on clean shutdown (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 
 ### 10.6.2-beta.3
 
-- Entities no longer **disappear** from Home Assistant when the app shuts down cleanly. A graceful exit published an empty capability list, which Home Assistant reads as "this device has nothing" and deletes the entities. Now only the availability state goes offline, so the entities stay and simply show as **unavailable** until the device is back — the same as after a crash or network loss. (Turning MQTT off in settings still removes them on purpose.)
+- Entities no longer **disappear** from Home Assistant when the app shuts down cleanly. A graceful exit published an empty capability list, which Home Assistant reads as "this device has nothing" and deletes the entities. Now only the availability state goes offline, so the entities stay and simply show as **unavailable** until the device is back — the same as after a crash or network loss. (Turning off both MQTT and the HA API in settings still removes them on purpose.)
 
 ### 10.6.2-beta.2
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.2--beta.2-orange)
+![Version](https://img.shields.io/badge/version-10.6.2--beta.3-orange)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -56,6 +56,10 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.2-beta.3
+
+- Entities no longer **disappear** from Home Assistant when the app shuts down cleanly. A graceful exit published an empty capability list, which Home Assistant reads as "this device has nothing" and deletes the entities. Now only the availability state goes offline, so the entities stay and simply show as **unavailable** until the device is back — the same as after a crash or network loss. (Turning MQTT off in settings still removes them on purpose.)
 
 ### 10.6.2-beta.2
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.2-beta.2"
+#define MyAppVersion "10.6.2-beta.3"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.2-beta.2</Version>
+    <Version>10.6.2-beta.3</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -487,7 +487,16 @@ internal sealed class MqttCompanionService : IDisposable
         if (publishOffline)
         {
             await PublishAvailabilityAsync(online: false);
-            await PublishDiscoveryAsync(offline: true);
+
+            // Only the service role publishes an offline state here: that just tells Home
+            // Assistant the service-handled commands are gone. The app role must NOT clear
+            // its discovery — the availability topic above already marks the entities
+            // unavailable, and publishing empty capabilities would make Home Assistant
+            // delete them instead of keeping them (greyed out) until the device is back.
+            if (_role == CompanionRuntimeRole.Service)
+            {
+                await PublishDiscoveryAsync(offline: true);
+            }
         }
         if (_mediaSessionService is not null)
         {


### PR DESCRIPTION
Follow-up reported in #15: on the fixed machine the entities **vanish** from Home Assistant when the device goes offline, instead of staying and showing as unavailable.

## Cause
Two separate mechanisms signal "offline":
- **Availability (LWT)** → entities go **unavailable but stay**. This is what we want.
- **Discovery** → the list of what the device offers. A graceful shutdown published an **empty** capability list, which Home Assistant reads as "this device has nothing left" and **deletes** the entities.

A clean exit published both, so the entities disappeared. After a crash or network loss only the Last Will fires — which is why the *good* behaviour was the one users normally saw, and why this only surfaced now: with the service-role NRE fixed, the app finally shuts down cleanly and hits the empty-discovery path.

## Fix
On shutdown the **app role** now publishes only the offline availability state — entities stay and grey out until the device is back. The **service role** still publishes its offline service status (that only marks service-handled commands gone), and **disabling MQTT in settings still clears discovery on purpose**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home Assistant entities now remain present but appear unavailable after a clean shutdown of the app.

* **Bug Fixes**
  * Improved shutdown behavior to prevent entities from being removed unexpectedly.

* **Documentation**
  * Updated release notes and version information for beta 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->