### PR TITLE
Remove code signing (SignPath) integration

### DIFF
--- a/.github/workflows/hass-agent-net10.yml
+++ b/.github/workflows/hass-agent-net10.yml
@@ -100,38 +100,6 @@ jobs:
           -p:PublishSingleFile=true
           -o $env:PUBLISH_DIR
 
-      # ── Code signing (SignPath) ──────────────────────────────────────
-      # The signing steps activate automatically once the SignPath secrets
-      # and variables are configured in the repository settings:
-      #   secret  SIGNPATH_API_TOKEN
-      #   vars    SIGNPATH_ORG_ID, SIGNPATH_PROJECT_SLUG, SIGNPATH_POLICY_SLUG
-      # Until then they are skipped and the build stays unsigned.
-      - name: Check code signing configuration
-        run: |
-          $configured = ("${{ secrets.SIGNPATH_API_TOKEN }}" -ne "") -and ("${{ vars.SIGNPATH_ORG_ID }}" -ne "")
-          $isRelease = ("${{ github.event_name }}" -eq "release") -or ("${{ github.ref }}".StartsWith("refs/tags/")) -or ("${{ github.event_name }}" -eq "workflow_dispatch")
-          "SIGNPATH_ENABLED=$(($configured -and $isRelease).ToString().ToLower())" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Upload unsigned app executable
-        if: env.SIGNPATH_ENABLED == 'true'
-        id: unsigned-exe
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unsigned-app-exe
-          path: ${{ env.PUBLISH_DIR }}/HASS.Agent.NET10.exe
-
-      - name: Sign app executable
-        if: env.SIGNPATH_ENABLED == 'true'
-        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORG_ID }}
-          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
-          github-artifact-id: ${{ steps.unsigned-exe.outputs.artifact-id }}
-          wait-for-completion: true
-          output-artifact-directory: ${{ env.PUBLISH_DIR }}
-
       - name: Install Inno Setup
         run: choco install innosetup --yes --no-progress
 
@@ -142,26 +110,6 @@ jobs:
             throw "Inno Setup compiler not found at $iscc"
           }
           & $iscc "installer\HASS.Agent.NET10.iss" "/DMyAppVersion=$env:APP_VERSION"
-
-      - name: Upload unsigned installer
-        if: env.SIGNPATH_ENABLED == 'true'
-        id: unsigned-installer
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unsigned-installer-exe
-          path: artifacts/installer/*.exe
-
-      - name: Sign installer
-        if: env.SIGNPATH_ENABLED == 'true'
-        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORG_ID }}
-          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
-          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
-          wait-for-completion: true
-          output-artifact-directory: artifacts/installer
 
       - name: Package published app
         run: |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 - [Local HTTP API](#local-http-api)
 - [Installer](#installer)
 - [Build from Source](#build-from-source)
-- [Code Signing Policy](#code-signing-policy)
 - [Privacy Policy](#privacy-policy)
 - [Windows Firewall](#windows-firewall)
 - [Minimal Development Setup](#minimal-development-setup)
@@ -712,15 +711,6 @@ This repository includes a Windows GitHub Actions workflow:
 - release assets on `v*` tags or published GitHub Releases:
   - `HASS.Agent.NET10-Setup-<version>.exe`
   - `HASS.Agent.NET10-win-x64-<version>.zip`
-
-## Code Signing Policy
-
-Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
-
-- Committers and reviewers: [@v1k70rk4](https://github.com/v1k70rk4)
-- Approvers: [@v1k70rk4](https://github.com/v1k70rk4)
-
-Release binaries are built and signed exclusively from this repository's source code by the GitHub Actions workflow above. Manually built binaries are never signed.
 
 ## Privacy Policy
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,7 +239,6 @@
       <a href="https://github.com/v1k70rk4/HASS.Agent.NET10/releases">Releases</a>
     </div>
     <div class="row" style="margin-top:14px; color:#64748b;">MIT licensed · Not affiliated with the Home Assistant project.</div>
-    <div class="row" style="color:#64748b;">Free code signing provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a>.</div>
   </div>
 </footer>
 


### PR DESCRIPTION
The SignPath Foundation open-source programme declined the project, so the signing steps can never activate. Removing the whole thing rather than keeping dead configuration — and a public credit for signing that doesn't happen.

- **workflow**: drop the signing config check, both unsigned-artifact uploads and both `signpath/github-action-submit-signing-request` steps
- **README**: drop the *Code Signing Policy* section and its table-of-contents entry
- **website** (`docs/index.html`): drop the SignPath credit from the footer

Releases are unsigned; nothing else in the build changes — the pipeline is still publish → Inno Setup installer → package → upload → release.

Supersedes #20 (a dependabot bump for the now-removed action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Distribution**
  * Release builds and installers are now produced without code signing.

* **Documentation**
  * Removed the Code Signing Policy from the documentation.
  * Removed the SignPath code-signing attribution from the website footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->