### PR TITLE
Release 10.6.3: protect settings and device identity across updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 
 ### 10.6.3
 
-- **Settings can no longer be lost when an update closes the app.** They were written by truncating the file first and then writing it, so a badly timed force-close could leave it empty. Settings are now written atomically and the previous version is kept as a backup, which is restored automatically if the main file ever turns up missing or unreadable.
+- **Settings are far harder to lose when an update closes the app.** They were written by truncating the file first and then writing it, so a badly timed force-close could leave it empty. Settings are now written atomically and the previous version is kept as a backup, which is restored automatically if the main file ever turns up missing or unreadable.
 - **A lost configuration no longer creates a duplicate device in Home Assistant.** The device serial is what identifies the PC, and it used to live only in the settings file — so losing that file minted a new serial and the machine reappeared as a brand new device (with the old entities left behind on the broker). The serial is now mirrored next to the settings and reused. A deliberate *Clean install* still gives a fresh identity, as it should.
 - **One-shot update tasks clean themselves up.** The scheduled tasks used to run an update were left behind in Task Scheduler, where they piled up and invited being run by hand. They now delete themselves after running, and leftovers from earlier versions are removed on start.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.2-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.3-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -55,6 +55,12 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.3
+
+- **Settings can no longer be lost when an update closes the app.** They were written by truncating the file first and then writing it, so a badly timed force-close could leave it empty. Settings are now written atomically and the previous version is kept as a backup, which is restored automatically if the main file ever turns up missing or unreadable.
+- **A lost configuration no longer creates a duplicate device in Home Assistant.** The device serial is what identifies the PC, and it used to live only in the settings file — so losing that file minted a new serial and the machine reappeared as a brand new device (with the old entities left behind on the broker). The serial is now mirrored next to the settings and reused. A deliberate *Clean install* still gives a fresh identity, as it should.
+- **One-shot update tasks clean themselves up.** The scheduled tasks used to run an update were left behind in Task Scheduler, where they piled up and invited being run by hand. They now delete themselves after running, and leftovers from earlier versions are removed on start.
 
 ### 10.6.2
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.2"
+#define MyAppVersion "10.6.3"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/Configuration/AppPaths.cs
+++ b/src/HASS.Agent.NET10/Configuration/AppPaths.cs
@@ -2,7 +2,7 @@ using HASS.Agent.Companion.Runtime;
 
 namespace HASS.Agent.Companion.Configuration;
 
-internal sealed record AppPaths(string ConfigDirectory, string SettingsFile, string LogFile)
+internal sealed record AppPaths(string ConfigDirectory, string SettingsFile, string LogFile, string DeviceIdFile)
 {
     public static AppPaths Create()
     {
@@ -33,6 +33,10 @@ internal sealed record AppPaths(string ConfigDirectory, string SettingsFile, str
         return new AppPaths(
             configDirectory,
             settingsFile,
-            Path.Combine(configDirectory, "hass-agent-net10.log"));
+            Path.Combine(configDirectory, "hass-agent-net10.log"),
+            // Mirrors the device serial so losing settings.json does not create a new
+            // device in Home Assistant. It lives in the config directory on purpose: a
+            // deliberate clean install wipes that directory and should give a fresh identity.
+            Path.Combine(configDirectory, "device-id"));
     }
 }

--- a/src/HASS.Agent.NET10/Configuration/SettingsStore.cs
+++ b/src/HASS.Agent.NET10/Configuration/SettingsStore.cs
@@ -69,7 +69,7 @@ internal static class SettingsStore
         // recovered content happens to match what we would have written.
         if (originalJson is null || restoredFromBackup || adoptedSerial || migratedPassword || migratedPasswordScope || migratedHaApiToken || !JsonEquals(originalJson, normalizedJson))
         {
-            Write(paths, normalizedJson);
+            Write(paths, normalizedJson, rotateBackup: !restoredFromBackup);
         }
 
         log.Info($"Loaded settings from {paths.SettingsFile}.");
@@ -193,18 +193,22 @@ internal static class SettingsStore
     /// leave it empty. Writing to a temp file and replacing keeps the previous content as a
     /// backup and never leaves a half-written settings file behind.
     /// </summary>
-    private static void Write(AppPaths paths, string json)
+    private static void Write(AppPaths paths, string json, bool rotateBackup = true)
     {
         Directory.CreateDirectory(paths.ConfigDirectory);
         var target = paths.SettingsFile;
-        var temp = target + ".tmp";
+        // Unique per write: the tray app and the service both save settings, so a shared
+        // temp path would let one process commit the other's content.
+        var temp = $"{target}.{Environment.ProcessId}.{Guid.NewGuid():N}.tmp";
 
         try
         {
             File.WriteAllText(temp, json);
             if (File.Exists(target))
             {
-                File.Replace(temp, target, BackupFile(paths), ignoreMetadataErrors: true);
+                // rotateBackup is off when recovering from the backup: the file we are
+                // replacing is the unreadable one, and it must not overwrite the good copy.
+                File.Replace(temp, target, rotateBackup ? BackupFile(paths) : null, ignoreMetadataErrors: true);
             }
             else
             {

--- a/src/HASS.Agent.NET10/Configuration/SettingsStore.cs
+++ b/src/HASS.Agent.NET10/Configuration/SettingsStore.cs
@@ -16,27 +16,71 @@ internal static class SettingsStore
     {
         CompanionSettings settings;
         string? originalJson = null;
+        var restoredFromBackup = false;
+
         if (File.Exists(paths.SettingsFile))
         {
             originalJson = File.ReadAllText(paths.SettingsFile);
-            settings = JsonSerializer.Deserialize<CompanionSettings>(originalJson, JsonOptions) ?? new CompanionSettings();
+            try
+            {
+                settings = JsonSerializer.Deserialize<CompanionSettings>(originalJson, JsonOptions) ?? new CompanionSettings();
+            }
+            catch (JsonException) when (TryReadBackup(paths, out var backupJson, out var backupSettings))
+            {
+                // The settings file is unreadable (a truncated write, for example) but the
+                // backup still parses — recover instead of starting from scratch.
+                settings = backupSettings!;
+                originalJson = backupJson;
+                restoredFromBackup = true;
+            }
+        }
+        else if (TryReadBackup(paths, out var backupJson, out var backupSettings))
+        {
+            settings = backupSettings!;
+            originalJson = backupJson;
+            restoredFromBackup = true;
         }
         else
         {
             settings = new CompanionSettings();
         }
 
+        // Restore the device serial from its sidecar before Normalize() would mint a new
+        // one: a lost settings file must not turn this PC into a new Home Assistant device.
+        var adoptedSerial = false;
+        if (string.IsNullOrWhiteSpace(settings.SerialNumber))
+        {
+            var storedSerial = ReadDeviceId(paths);
+            if (storedSerial is not null)
+            {
+                settings.SerialNumber = storedSerial;
+                adoptedSerial = true;
+            }
+        }
+
         settings.Normalize();
+        WriteDeviceId(paths, settings.SerialNumber);
         var migratedPassword = settings.MigratePlainTextPassword();
         var migratedPasswordScope = settings.MigrateProtectedPasswordToMachineScope();
         var migratedHaApiToken = settings.MigrateHaApiPlainTextToken();
         var normalizedJson = Serialize(settings);
-        if (originalJson is null || migratedPassword || migratedPasswordScope || migratedHaApiToken || !JsonEquals(originalJson, normalizedJson))
+        // restoredFromBackup/adoptedSerial force a write: the settings file itself is
+        // missing or unreadable in those cases and has to be rebuilt, even when the
+        // recovered content happens to match what we would have written.
+        if (originalJson is null || restoredFromBackup || adoptedSerial || migratedPassword || migratedPasswordScope || migratedHaApiToken || !JsonEquals(originalJson, normalizedJson))
         {
             Write(paths, normalizedJson);
         }
 
         log.Info($"Loaded settings from {paths.SettingsFile}.");
+        if (restoredFromBackup)
+        {
+            log.Warning($"Settings were unreadable or missing; restored from {Path.GetFileName(BackupFile(paths))}.");
+        }
+        if (adoptedSerial)
+        {
+            log.Warning("Settings were reset; kept the existing device serial so Home Assistant sees the same device.");
+        }
         if (migratedPassword)
         {
             log.Info("Migrated MQTT password to Windows protected storage.");
@@ -76,10 +120,117 @@ internal static class SettingsStore
         return settings;
     }
 
+    private static string BackupFile(AppPaths paths) => paths.SettingsFile + ".bak";
+
+    private static bool TryReadBackup(AppPaths paths, out string? json, out CompanionSettings? settings)
+    {
+        json = null;
+        settings = null;
+        var backup = BackupFile(paths);
+        if (!File.Exists(backup))
+        {
+            return false;
+        }
+
+        try
+        {
+            var backupJson = File.ReadAllText(backup);
+            var parsed = JsonSerializer.Deserialize<CompanionSettings>(backupJson, JsonOptions);
+            if (parsed is null)
+            {
+                return false;
+            }
+
+            json = backupJson;
+            settings = parsed;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? ReadDeviceId(AppPaths paths)
+    {
+        try
+        {
+            if (!File.Exists(paths.DeviceIdFile))
+            {
+                return null;
+            }
+
+            var value = File.ReadAllText(paths.DeviceIdFile).Trim();
+            return value.Length > 0 ? value : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void WriteDeviceId(AppPaths paths, string serialNumber)
+    {
+        if (string.IsNullOrWhiteSpace(serialNumber) || ReadDeviceId(paths) == serialNumber)
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(paths.ConfigDirectory);
+            File.WriteAllText(paths.DeviceIdFile, serialNumber);
+        }
+        catch
+        {
+            // Best effort: the serial in settings.json remains the source of truth.
+        }
+    }
+
+    /// <summary>
+    /// Writes the settings atomically. A plain write truncates the file first, so a process
+    /// kill at the wrong moment (the installer force-closes the app during an update) could
+    /// leave it empty. Writing to a temp file and replacing keeps the previous content as a
+    /// backup and never leaves a half-written settings file behind.
+    /// </summary>
     private static void Write(AppPaths paths, string json)
     {
         Directory.CreateDirectory(paths.ConfigDirectory);
-        File.WriteAllText(paths.SettingsFile, json);
+        var target = paths.SettingsFile;
+        var temp = target + ".tmp";
+
+        try
+        {
+            File.WriteAllText(temp, json);
+            if (File.Exists(target))
+            {
+                File.Replace(temp, target, BackupFile(paths), ignoreMetadataErrors: true);
+            }
+            else
+            {
+                File.Move(temp, target);
+            }
+
+            return;
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(temp))
+                {
+                    File.Delete(temp);
+                }
+            }
+            catch
+            {
+                // Ignore: the direct write below is what matters.
+            }
+        }
+
+        // Fall back to a direct write so a locked file or a failed replace can never stop
+        // settings from being saved at all.
+        File.WriteAllText(target, json);
     }
 
     private static string Serialize(CompanionSettings settings)

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.2</Version>
+    <Version>10.6.3</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -390,7 +390,10 @@ internal sealed class MqttCompanionService : IDisposable
     {
         RunSchtasks($"/delete /tn \"{taskName}\" /f", ignoreErrors: true);
         var runAs = asSystem ? " /ru SYSTEM /rl HIGHEST" : string.Empty;
-        RunSchtasks($"/create /tn \"{taskName}\" /tr \"{batchPath}\" /sc once /st 00:00{runAs} /f");
+        // /z makes Windows delete the task after its final run so these one-shot tasks do
+        // not pile up in Task Scheduler (where users are tempted to run them by hand).
+        // /z is rejected without an end boundary, hence /et.
+        RunSchtasks($"/create /tn \"{taskName}\" /tr \"{batchPath}\" /sc once /st 00:00 /et 23:59 /z{runAs} /f");
         RunSchtasks($"/run /tn \"{taskName}\"");
     }
 

--- a/src/HASS.Agent.NET10/Program.cs
+++ b/src/HASS.Agent.NET10/Program.cs
@@ -109,6 +109,10 @@ internal static class Program
 
         Localization.Strings.Language = settings.Language;
         Localization.Strings.HaLanguage = settings.HaLanguage;
+
+        // If an update ran, its one-shot scheduled tasks have already done their job by the
+        // time we are up again. Clear any left behind (older versions never removed them).
+        _ = Task.Run(() => DetachedUpdateLauncher.CleanUpLeftoverTasks(log));
         try
         {
             if (!settings.AutoStartOnLogin && StartupManager.IsEnabled())

--- a/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
+++ b/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
@@ -40,7 +40,9 @@ internal static class DetachedUpdateLauncher
                 $"start \"\" \"{installerPath}\"" + Environment.NewLine);
 
             RunSchtasks($"/delete /tn \"{TaskName}\" /f", log, ignoreErrors: true);
-            if (!RunSchtasks($"/create /tn \"{TaskName}\" /tr \"\\\"{batchPath}\\\"\" /sc once /st 00:00 /f", log))
+            // /z deletes the task after it runs (it needs an end boundary, hence /et) so
+            // one-shot update tasks do not accumulate in Task Scheduler.
+            if (!RunSchtasks($"/create /tn \"{TaskName}\" /tr \"\\\"{batchPath}\\\"\" /sc once /st 00:00 /et 23:59 /z /f", log))
             {
                 return false;
             }
@@ -57,6 +59,19 @@ internal static class DetachedUpdateLauncher
         {
             log.Warning($"Detached installer launch failed: {ex.Message}");
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Removes one-shot update tasks left behind by earlier versions. They served their
+    /// purpose long before the app is running again, and leaving them in Task Scheduler
+    /// invites users to run them by hand — which is not something they are built for.
+    /// </summary>
+    public static void CleanUpLeftoverTasks(FileLog log)
+    {
+        foreach (var name in new[] { TaskName, "HASSAgentNet10Update", "HASSAgentNet10Relaunch" })
+        {
+            RunSchtasks($"/delete /tn \"{name}\" /f", log, ignoreErrors: true);
         }
     }
 


### PR DESCRIPTION
Follow-up to #22, where a machine came back from an update with default settings and a **freshly generated serial** — so Home Assistant discovered it as a *new* device while the old retained discovery data stayed on the broker.

The exact trigger on that machine couldn't be proven (the evidence was gone by the time we looked), but three things were wrong regardless of it, and each is worth fixing on its own merit.

## Changes

- **Atomic settings write.** `SettingsStore.Write` used `File.WriteAllText`, which truncates the file *before* writing — and the installer force-closes the app during an update, so a badly timed kill could leave an empty settings file. It now writes to a temp file and `File.Replace`s it, keeping the previous content as `settings.json.bak`. A direct write remains as a fallback so a locked file can never stop settings from being saved at all.
- **Backup recovery.** If `settings.json` is missing or doesn't parse, the backup is used and the main file is rewritten.
- **Device identity survives a lost configuration.** The serial identifying the PC lived *only* in `settings.json`, so losing that file minted a new GUID → new device in Home Assistant. It's now mirrored to a `device-id` file and reused. It deliberately sits in the config directory: a **Clean install** wipes that directory and *should* give a fresh identity.
- **One-shot update tasks clean themselves up.** They were left in Task Scheduler forever, piling up (the reporter had three) — and visible enough that he ran them by hand, which is not what they're built for. They're now created with `/z` so Windows deletes them after running, and leftovers from earlier versions are removed on start.

## Verification

- `/z` is rejected without an end boundary (`schtasks` exits 1 and the task is **not created**) — verified locally, so it's paired with `/et 23:59`. Without checking this, updates would have silently stopped working.
- The atomic write + rolling backup semantics were verified locally: first write creates the file with no backup, subsequent writes update it and keep the previous content, and no temp file is left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings are now saved more reliably with atomic writes and backup recovery.
  * Device identity is preserved when settings are restored or recreated.
  * One-time update tasks are automatically removed after execution.

* **Bug Fixes**
  * Improved recovery from missing or corrupted settings files.
  * Cleaned up leftover update and relaunch tasks.

* **Chores**
  * Updated the application and installer version to 10.6.3.
  * Added release notes to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->