### PR TITLE
installer: clean install is never remembered and never runs silently

### DIFF
--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -54,7 +54,10 @@ hungarian.StatusFirewall=Tűzfal beállítása...
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "autostart"; Description: "{cm:TaskAutostart}"; GroupDescription: "{cm:TaskGroupStartup}"
 Name: "installservice"; Description: "{cm:TaskInstallService}"; GroupDescription: "{cm:TaskGroupOptional}"; Flags: unchecked
-Name: "cleaninstall"; Description: "{cm:TaskCleanInstall}"; GroupDescription: "{cm:TaskGroupAdvanced}"; Flags: unchecked
+; checkedonce: Setup remembers task selections across runs (UsePreviousTasks),
+; so one past clean install would silently repeat on every later update.
+; This keeps the task available but never pre-ticked on an upgrade.
+Name: "cleaninstall"; Description: "{cm:TaskCleanInstall}"; GroupDescription: "{cm:TaskGroupAdvanced}"; Flags: unchecked checkedonce
 
 [Files]
 Source: "..\artifacts\HASS.Agent.NET10\win-x64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -169,7 +172,9 @@ begin
       Sleep(1500);
     end;
 
-    if WizardIsTaskSelected('cleaninstall') then
+    { Destructive, so never in silent mode: unattended updates (from Home
+      Assistant or in-app) must not wipe settings under any circumstances. }
+    if WizardIsTaskSelected('cleaninstall') and (not WizardSilent()) then
     begin
       DelTree(ExpandConstant('{commonappdata}\HASS.Agent.NET10'), True, True, True);
       { Also remove legacy directories so the migration does not restore old settings. }


### PR DESCRIPTION
Explains the recurring wiped settings in #22 — and this time it's not a guess.

## The mechanism
Inno Setup's `UsePreviousTasks` defaults to **yes**: *"at startup Setup will look in the registry to see if the same application is already installed, and if so, it will use the task settings of the previous installation"*. The reporter confirmed he ran a **Clean install** on the affected machine — so that tick was remembered, and **every subsequent update re-applied it**, including unattended (HA-triggered) updates where no wizard ever shows the tick. That wipes `settings.json`, the backup **and** the new `device-id` sidecar → fresh serial → duplicate device. It also explains why 10.6.3's protections didn't help: the installer was deleting the whole directory on purpose, as instructed.

## The fix
- `cleaninstall` gets the **`checkedonce`** flag — documented as *"unchecked initially when Setup finds a previous version of the same application is already installed"*. The task stays in the wizard, but an upgrade never inherits a past tick.
- The wipe additionally requires **`not WizardSilent()`** — a destructive action never runs unattended, regardless of any remembered state. Belt and braces.

## Verification
Compiled locally with ISCC 6.7.3 (exit 0). First attempt used `{ }` comments in the `[Tasks]` section, which is a compile error outside `[Code]` — caught locally; CI would have failed on the next tag.

The stuck-"Queued" scheduled tasks on the same machine (updates not starting) are a separate question — likely the default battery condition on `schtasks`-created tasks; awaiting the reporter's confirmation before touching that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the clean-install option selection between installer runs.
  * Prevented unattended or silent updates from deleting existing configuration settings.

* **Installer Improvements**
  * Added clearer guidance around clean-install behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->