### PR TITLE
Release 10.6.4: update tasks run on battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.3-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.4-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -55,6 +55,15 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.4
+
+Both fixes address the update problems reported in #22.
+
+- **Updates now start on battery.** The one-shot tasks that run an update carried Task Scheduler's default battery conditions ("start only on AC power", "stop when switching to battery"), so on a notebook running on battery the update never started — the tasks just sat *Queued*. The tasks are now created from an explicit definition that allows battery power, and they still remove themselves afterwards.
+- **"Clean install" is never remembered and never runs silently.** The installer remembers task selections from previous runs, so ticking *Clean install* once made **every later update** on that machine silently repeat it — wiping the settings and the device id, which is why the PC kept reappearing in Home Assistant as a new device. The tick now always starts unchecked on an upgrade, and an unattended (silent) update can never wipe settings at all.
+
+Thanks to [@AdmiralRaccoon](https://github.com/AdmiralRaccoon) for the report and for methodically confirming both causes — registry value and Task Scheduler conditions included.
 
 ### 10.6.3
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.3"
+#define MyAppVersion "10.6.4"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.3</Version>
+    <Version>10.6.4</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -385,47 +385,11 @@ internal sealed class MqttCompanionService : IDisposable
     /// <summary>
     /// Runs a batch file via a one-shot scheduled task, fully detached from this
     /// process tree so it survives both service stop and taskkill /T on the tray app.
+    /// The task is battery-friendly and deletes itself (see DetachedTaskRunner).
     /// </summary>
     private void RunDetachedTask(string taskName, string batchPath, bool asSystem)
     {
-        RunSchtasks($"/delete /tn \"{taskName}\" /f", ignoreErrors: true);
-        var runAs = asSystem ? " /ru SYSTEM /rl HIGHEST" : string.Empty;
-        // /z makes Windows delete the task after its final run so these one-shot tasks do
-        // not pile up in Task Scheduler (where users are tempted to run them by hand).
-        // /z is rejected without an end boundary, hence /et.
-        RunSchtasks($"/create /tn \"{taskName}\" /tr \"{batchPath}\" /sc once /st 00:00 /et 23:59 /z{runAs} /f");
-        RunSchtasks($"/run /tn \"{taskName}\"");
-    }
-
-    private void RunSchtasks(string arguments, bool ignoreErrors = false)
-    {
-        try
-        {
-            using var process = Process.Start(new ProcessStartInfo
-            {
-                FileName = "schtasks.exe",
-                Arguments = arguments,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            });
-
-            if (process is null)
-            {
-                return;
-            }
-
-            process.WaitForExit(10_000);
-            if (process.ExitCode != 0 && !ignoreErrors)
-            {
-                _log.Warning($"schtasks {arguments} exited with code {process.ExitCode}: {process.StandardError.ReadToEnd().Trim()}");
-            }
-        }
-        catch (Exception ex) when (ignoreErrors)
-        {
-            _log.Debug($"schtasks {arguments} failed (ignored): {ex.Message}");
-        }
+        DetachedTaskRunner.RunOnce(taskName, batchPath, asSystem, _log);
     }
 
     private static bool IsInstallerAsset(string? assetName)

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -389,7 +389,12 @@ internal sealed class MqttCompanionService : IDisposable
     /// </summary>
     private void RunDetachedTask(string taskName, string batchPath, bool asSystem)
     {
-        DetachedTaskRunner.RunOnce(taskName, batchPath, asSystem, _log);
+        if (!DetachedTaskRunner.RunOnce(taskName, batchPath, asSystem, _log))
+        {
+            // Loudly: a silently missing update task is exactly how the battery-condition
+            // problem stayed invisible in the logs (#22).
+            _log.Warning($"Detached task '{taskName}' could not be created or started.");
+        }
     }
 
     private static bool IsInstallerAsset(string? assetName)

--- a/src/HASS.Agent.NET10/Runtime/DetachedTaskRunner.cs
+++ b/src/HASS.Agent.NET10/Runtime/DetachedTaskRunner.cs
@@ -1,0 +1,149 @@
+using System.Diagnostics;
+using System.Security.Principal;
+using System.Text;
+using HASS.Agent.Companion.Logging;
+
+namespace HASS.Agent.Companion.Runtime;
+
+/// <summary>
+/// Creates and starts a one-shot scheduled task detached from this process tree.
+///
+/// The task is registered from an XML definition instead of plain schtasks switches,
+/// because the switches offer no way to clear the scheduler's default battery
+/// conditions ("start only on AC power", "stop when switching to battery") — which
+/// left update tasks sitting "Queued" forever on notebooks running on battery.
+/// The XML also sets DeleteExpiredTaskAfter with an end boundary, so the task removes
+/// itself instead of piling up in Task Scheduler.
+/// </summary>
+internal static class DetachedTaskRunner
+{
+    public static bool RunOnce(string taskName, string commandPath, bool asSystem, FileLog log)
+    {
+        Delete(taskName, log);
+
+        var now = DateTime.Now;
+        // SYSTEM tasks authenticate by the well-known SID; user tasks run with the
+        // interactive token of the logged-on user who created them.
+        var principal = asSystem
+            ? "      <UserId>S-1-5-18</UserId>\n      <RunLevel>HighestAvailable</RunLevel>"
+            : "      <UserId>" + (WindowsIdentity.GetCurrent().User?.Value ?? Environment.UserName) + "</UserId>\n" +
+              "      <LogonType>InteractiveToken</LogonType>\n      <RunLevel>LeastPrivilege</RunLevel>";
+
+        var xml =
+            "<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n" +
+            "<Task version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n" +
+            "  <RegistrationInfo>\n" +
+            "    <Description>HASS.Agent .NET10 one-shot task. Created automatically; safe to delete.</Description>\n" +
+            "  </RegistrationInfo>\n" +
+            "  <Triggers>\n" +
+            "    <TimeTrigger>\n" +
+            $"      <StartBoundary>{now:yyyy-MM-ddTHH:mm:ss}</StartBoundary>\n" +
+            $"      <EndBoundary>{now.AddDays(2):yyyy-MM-ddTHH:mm:ss}</EndBoundary>\n" +
+            "      <Enabled>true</Enabled>\n" +
+            "    </TimeTrigger>\n" +
+            "  </Triggers>\n" +
+            "  <Principals>\n" +
+            "    <Principal id=\"Author\">\n" +
+            principal + "\n" +
+            "    </Principal>\n" +
+            "  </Principals>\n" +
+            "  <Settings>\n" +
+            "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n" +
+            "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n" +
+            "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n" +
+            "    <AllowHardTerminate>true</AllowHardTerminate>\n" +
+            "    <StartWhenAvailable>false</StartWhenAvailable>\n" +
+            "    <AllowStartOnDemand>true</AllowStartOnDemand>\n" +
+            "    <Enabled>true</Enabled>\n" +
+            "    <Hidden>false</Hidden>\n" +
+            "    <RunOnlyIfIdle>false</RunOnlyIfIdle>\n" +
+            "    <WakeToRun>false</WakeToRun>\n" +
+            "    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>\n" +
+            "    <DeleteExpiredTaskAfter>PT0S</DeleteExpiredTaskAfter>\n" +
+            "  </Settings>\n" +
+            "  <Actions Context=\"Author\">\n" +
+            "    <Exec>\n" +
+            $"      <Command>\"{commandPath}\"</Command>\n" +
+            "    </Exec>\n" +
+            "  </Actions>\n" +
+            "</Task>\n";
+
+        var xmlPath = Path.Combine(
+            Path.GetDirectoryName(commandPath) ?? Path.GetTempPath(),
+            $"{taskName}.xml");
+
+        try
+        {
+            // schtasks only accepts the XML when the file encoding matches its
+            // declaration, so this must be written as UTF-16.
+            File.WriteAllText(xmlPath, xml, Encoding.Unicode);
+
+            if (!RunSchtasks($"/create /tn \"{taskName}\" /xml \"{xmlPath}\" /f", log))
+            {
+                return false;
+            }
+
+            return RunSchtasks($"/run /tn \"{taskName}\"", log);
+        }
+        catch (Exception ex)
+        {
+            log.Warning($"Detached task '{taskName}' failed: {ex.Message}");
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(xmlPath);
+            }
+            catch
+            {
+                // Best effort; a stray xml file in the update directory is harmless.
+            }
+        }
+    }
+
+    public static void Delete(string taskName, FileLog log)
+    {
+        RunSchtasks($"/delete /tn \"{taskName}\" /f", log, ignoreErrors: true);
+    }
+
+    private static bool RunSchtasks(string arguments, FileLog log, bool ignoreErrors = false)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "schtasks.exe",
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            });
+
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit(10_000);
+            if (process.ExitCode != 0)
+            {
+                if (!ignoreErrors)
+                {
+                    log.Warning($"schtasks {arguments} exited with code {process.ExitCode}: {process.StandardError.ReadToEnd().Trim()}");
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ignoreErrors)
+        {
+            log.Debug($"schtasks {arguments} failed (ignored): {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/HASS.Agent.NET10/Runtime/DetachedTaskRunner.cs
+++ b/src/HASS.Agent.NET10/Runtime/DetachedTaskRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Security;
 using System.Security.Principal;
 using System.Text;
 using HASS.Agent.Companion.Logging;
@@ -63,7 +64,9 @@ internal static class DetachedTaskRunner
             "  </Settings>\n" +
             "  <Actions Context=\"Author\">\n" +
             "    <Exec>\n" +
-            $"      <Command>\"{commandPath}\"</Command>\n" +
+            // XML-escaped: & or similar in the path (user-profile names can contain
+            // them, and the batch lives under the user's temp) would break the XML.
+            $"      <Command>\"{SecurityElement.Escape(commandPath)}\"</Command>\n" +
             "    </Exec>\n" +
             "  </Actions>\n" +
             "</Task>\n";
@@ -127,7 +130,17 @@ internal static class DetachedTaskRunner
                 return false;
             }
 
-            process.WaitForExit(10_000);
+            // On timeout the process is still running, so ExitCode would throw.
+            if (!process.WaitForExit(10_000))
+            {
+                if (!ignoreErrors)
+                {
+                    log.Warning($"schtasks {arguments} timed out.");
+                }
+
+                return false;
+            }
+
             if (process.ExitCode != 0)
             {
                 if (!ignoreErrors)

--- a/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
+++ b/src/HASS.Agent.NET10/Runtime/DetachedUpdateLauncher.cs
@@ -39,15 +39,7 @@ internal static class DetachedUpdateLauncher
                 "@echo off" + Environment.NewLine +
                 $"start \"\" \"{installerPath}\"" + Environment.NewLine);
 
-            RunSchtasks($"/delete /tn \"{TaskName}\" /f", log, ignoreErrors: true);
-            // /z deletes the task after it runs (it needs an end boundary, hence /et) so
-            // one-shot update tasks do not accumulate in Task Scheduler.
-            if (!RunSchtasks($"/create /tn \"{TaskName}\" /tr \"\\\"{batchPath}\\\"\" /sc once /st 00:00 /et 23:59 /z /f", log))
-            {
-                return false;
-            }
-
-            if (!RunSchtasks($"/run /tn \"{TaskName}\"", log))
+            if (!DetachedTaskRunner.RunOnce(TaskName, batchPath, asSystem: false, log))
             {
                 return false;
             }
@@ -71,46 +63,8 @@ internal static class DetachedUpdateLauncher
     {
         foreach (var name in new[] { TaskName, "HASSAgentNet10Update", "HASSAgentNet10Relaunch" })
         {
-            RunSchtasks($"/delete /tn \"{name}\" /f", log, ignoreErrors: true);
+            DetachedTaskRunner.Delete(name, log);
         }
     }
 
-    private static bool RunSchtasks(string arguments, FileLog log, bool ignoreErrors = false)
-    {
-        try
-        {
-            using var process = Process.Start(new ProcessStartInfo
-            {
-                FileName = "schtasks.exe",
-                Arguments = arguments,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            });
-
-            if (process is null)
-            {
-                return false;
-            }
-
-            process.WaitForExit(10_000);
-            if (process.ExitCode != 0)
-            {
-                if (!ignoreErrors)
-                {
-                    log.Warning($"schtasks {arguments} exited with code {process.ExitCode}: {process.StandardError.ReadToEnd().Trim()}");
-                }
-
-                return false;
-            }
-
-            return true;
-        }
-        catch (Exception ex) when (ignoreErrors)
-        {
-            log.Debug($"schtasks {arguments} failed (ignored): {ex.Message}");
-            return false;
-        }
-    }
 }


### PR DESCRIPTION
Second half of #22 — both suspects are now **confirmed by the reporter**: the wiped settings came from a remembered *Clean install* tick (the registry value contained `cleaninstall`; fixed in #24), and the never-starting updates came from Task Scheduler's **battery conditions**: his notebook runs mostly on battery, and both `HASSAgentNet10*` tasks had *"start only on AC power"* and *"stop when switching to battery"* ticked — leaving them permanently **Queued**.

## Change
`schtasks` switches can't clear those conditions, so one-shot tasks are now registered from an **XML definition** via a shared `DetachedTaskRunner`, used by all three call sites (service update, relaunch watchdog, in-app update):

- `DisallowStartIfOnBatteries` and `StopIfGoingOnBatteries` are **off** → updates start and finish on battery
- `DeleteExpiredTaskAfter` + trigger end boundary keeps the self-deletion that `/z` used to provide
- SYSTEM tasks keep the well-known SID + highest run level; user tasks keep the interactive token at least privilege — same as before
- the XML is written as **UTF-16** to match its declaration (schtasks rejects it otherwise)

Also consolidates the previously duplicated `schtasks` wrappers into the new helper.

## Verification (local, end to end)
Task created from the same XML template: exit 0, `DisallowStartIfOnBatteries=False`, `StopIfGoingOnBatteries=False`, `DeleteExpiredTaskAfter=PT0S`, `/run` succeeds, task deletable.

Bumps to **10.6.4**; the changelog covers this and the already-merged clean-install fix. Tag comes separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 10.6.4.
  - Improved update tasks to continue operating reliably when the device is running on battery power.
  - Added safeguards to prevent clean installations from completing silently or leaving behind persisted update tasks.

- **Bug Fixes**
  - Improved background update execution and cleanup.
  - Enhanced reporting when update tasks cannot be created or started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->