### PR TITLE
Release 10.6.5: one shared button-command path for every transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.4-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.5-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -55,6 +55,12 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.5
+
+- **Custom commands now work over the Home Assistant API (WebSocket) transport.** Pressing a custom command button did nothing when running without MQTT — the log only showed `Unsupported app WebSocket command received: <id>`. Built-in commands were unaffected. Each transport carried its own copy of the "what does this button mean" logic, and only the MQTT one knew about custom commands; all transports now share a single implementation, so they cannot drift apart again.
+
+Thanks to [@CookSleep](https://github.com/CookSleep) for the report — including the root cause and a suggested fix.
 
 ### 10.6.4
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.4"
+#define MyAppVersion "10.6.5"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.4</Version>
+    <Version>10.6.5</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -535,17 +535,10 @@ internal sealed class MqttCompanionService : IDisposable
             };
             _haWs.ButtonCommandReceived += command =>
             {
-                var commandName = GetSystemCommandName(command);
-                var enabled = _role == CompanionRuntimeRole.Service
-                    ? commandName is not null && _settings.IsServiceCommandEnabled(commandName)
-                    : commandName is not null && _settings.IsTrayAppCommandEnabled(commandName);
-                if (enabled)
-                {
-                    _ = _systemCommandService.HandleCommandAsync(command);
-                    return;
-                }
-
-                _log.Warning($"Unsupported {_role.Token()} WebSocket command received: {commandName ?? "(empty)"}");
+                _ = ExecuteButtonCommandAsync(
+                    command,
+                    serviceRole: _role == CompanionRuntimeRole.Service,
+                    transport: "the HA API WebSocket");
             };
         }
 
@@ -1096,27 +1089,7 @@ internal sealed class MqttCompanionService : IDisposable
                 var command = JsonSerializer.Deserialize<SystemCommandMessage>(payload, JsonOptions);
                 if (command is not null)
                 {
-                    var commandName = GetSystemCommandName(command);
-                    if (commandName is null)
-                    {
-                        _log.Warning("Received empty tray app command.");
-                        return;
-                    }
-
-                    var customCommand = FindCustomCommand(commandName, serviceRole: false);
-                    if (customCommand is not null)
-                    {
-                        await _systemCommandService.RunCustomCommandAsync(customCommand);
-                        return;
-                    }
-
-                    if (!_settings.IsTrayAppCommandEnabled(commandName))
-                    {
-                        _log.Warning($"Unsupported tray app command received: {commandName}");
-                        return;
-                    }
-
-                    await _systemCommandService.HandleCommandAsync(command);
+                    await ExecuteButtonCommandAsync(command, serviceRole: false, transport: "MQTT");
                 }
             }
 
@@ -1135,11 +1108,9 @@ internal sealed class MqttCompanionService : IDisposable
                 var command = JsonSerializer.Deserialize<SystemCommandMessage>(payload, JsonOptions);
                 if (command is not null)
                 {
-                    var commandName = GetSystemCommandName(command);
-
                     // Internal command, not user-configurable: the tray app asks the
                     // SYSTEM service to install an update without a UAC prompt.
-                    if (commandName == "install_update")
+                    if (GetSystemCommandName(command) == "install_update")
                     {
                         if (_role == CompanionRuntimeRole.Service)
                         {
@@ -1149,26 +1120,7 @@ internal sealed class MqttCompanionService : IDisposable
                         return;
                     }
 
-                    if (commandName is null)
-                    {
-                        _log.Warning("Received empty system service command.");
-                        return;
-                    }
-
-                    var customCommand = FindCustomCommand(commandName, serviceRole: true);
-                    if (customCommand is not null)
-                    {
-                        await _systemCommandService.RunCustomCommandAsync(customCommand);
-                        return;
-                    }
-
-                    if (!_settings.IsServiceCommandEnabled(commandName))
-                    {
-                        _log.Warning($"Unsupported system service command received: {commandName}");
-                        return;
-                    }
-
-                    await _systemCommandService.HandleCommandAsync(command);
+                    await ExecuteButtonCommandAsync(command, serviceRole: true, transport: "MQTT");
                 }
             }
         }
@@ -1535,6 +1487,49 @@ internal sealed class MqttCompanionService : IDisposable
         return _role == CompanionRuntimeRole.Service
             ? _settings.MqttServiceSystemSensorsEnabled
             : _settings.MqttSystemSensorsEnabled;
+    }
+
+    /// <summary>
+    /// Decides what an incoming button command means and runs it: a user-defined custom
+    /// command, an enabled built-in system command, or neither. Every transport routes
+    /// through here — MQTT and the HA API WebSocket each used to carry their own copy of
+    /// this decision, and the WebSocket one silently never ran custom commands (#26).
+    /// </summary>
+    private async Task ExecuteButtonCommandAsync(SystemCommandMessage command, bool serviceRole, string transport)
+    {
+        var scope = serviceRole ? "system service" : "tray app";
+        try
+        {
+            var commandName = GetSystemCommandName(command);
+            if (commandName is null)
+            {
+                _log.Warning($"Received empty {scope} command over {transport}.");
+                return;
+            }
+
+            var customCommand = FindCustomCommand(commandName, serviceRole);
+            if (customCommand is not null)
+            {
+                await _systemCommandService.RunCustomCommandAsync(customCommand);
+                return;
+            }
+
+            var enabled = serviceRole
+                ? _settings.IsServiceCommandEnabled(commandName)
+                : _settings.IsTrayAppCommandEnabled(commandName);
+            if (!enabled)
+            {
+                _log.Warning($"Unsupported {scope} command received over {transport}: {commandName}");
+                return;
+            }
+
+            await _systemCommandService.HandleCommandAsync(command);
+        }
+        catch (Exception ex)
+        {
+            // The WebSocket transport invokes this without an outer handler.
+            _log.Warning($"Failed to run {scope} command from {transport}: {ex.Message}");
+        }
     }
 
     private static string? GetSystemCommandName(SystemCommandMessage message)


### PR DESCRIPTION
Fixes #26 — and removes the duplication that caused it.

## The bug
Custom commands never ran over the **HA API (WebSocket)** transport. The WebSocket handler went straight to `IsTrayAppCommandEnabled`, which is false for a custom command id, so it only logged `Unsupported app WebSocket command received: <id>`. Built-in commands worked fine over the same connection, which is exactly why this stayed hidden.

@CookSleep diagnosed it correctly and even suggested a patch. One small correction to the write-up: `GetSystemCommandName` doesn't return `null` for a custom id — it returns the raw command lowercased, which is why the log shows the guid rather than `(empty)`. Doesn't change the conclusion.

## The fix
The real cause was **duplication**: three handlers (MQTT tray topic, MQTT service topic, WebSocket) each carried their own copy of the same decision, and only the MQTT ones knew about custom commands. Rather than adding the missing lookup to the third copy — and waiting for the fourth to drift — all three now call one `ExecuteButtonCommandAsync`, which:

1. resolves a user-defined custom command first,
2. then an enabled built-in system command,
3. otherwise logs a warning naming the scope **and the transport** it arrived on.

`FindCustomCommand` has a single caller again.

## Behaviour preserved
- the buttons topic keeps **tray-app** scope (verified: the service subscribes only to its own topic and returns early), the service topic keeps **service** scope
- `install_update` stays a separate internal path, before the shared logic
- the shared method catches and logs, since the WebSocket transport invokes it without an outer handler

## Checked for a second gap
The WebSocket transport carries three command types: `notification`, `media_command`, `button_command`. MQTT additionally has the update-install topic — but that's by design, not a second bug: the update entity comes from MQTT discovery and the integration has no update platform, so an HA-API-only setup has no update entity at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom commands now work when received through the Home Assistant WebSocket API.
  * MQTT and WebSocket button commands now provide consistent handling for built-in and custom commands.
* **Bug Fixes**
  * Improved validation and handling of unsupported or failed button commands.
* **Release**
  * Updated the application and installer to version 10.6.5.
  * Added release notes documenting WebSocket support for custom commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->