### PR TITLE
Give the system service its own channel on the HA API transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ The agent supports three connection modes. You can use MQTT and HA API together 
 | Command buttons | yes | yes | |
 | Update entity | yes | yes | |
 | Auto-discovery | yes | yes | |
-| Service integration | yes | | |
+| Service integration | yes | yes | |
 | Retained state on restart | yes | | |
 | Last Will (offline detection) | yes | | |
 | Remote access (Nabu Casa) | | yes | |
@@ -636,7 +636,8 @@ When using HA API mode, the agent communicates through Home Assistant's event bu
 Events fired by the agent:
 
 ```text
-hass_agent_device_update          # discovery + capabilities
+hass_agent_device_update          # discovery + capabilities (tray app)
+hass_agent_service_update         # Windows service status + capabilities
 hass_agent_sensor_update          # sensor values
 hass_agent_media_update           # media player state
 hass_agent_media_thumbnail        # media thumbnail (base64)
@@ -649,9 +650,14 @@ Commands sent by the integration to the agent:
 {
   "serial_number": "agent-serial",
   "command_type": "notification | media_command | button_command",
+  "target": "app | service",
   "payload": { }
 }
 ```
+
+`target` names which side should act on a button command — the tray app or the Windows
+service — the same choice MQTT makes by picking a topic. It is optional: without it each
+side falls back to deciding for itself, which is how integrations older than 10.6.5 behave.
 
 All events and commands are targeted by `serial_number`, so renaming the device in Home Assistant does not break routing.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 
 ### 10.6.5
 
+Requires the Home Assistant integration **10.6.5** or newer when using the HA API (WebSocket) transport.
+
 - **Custom commands now work over the Home Assistant API (WebSocket) transport.** Pressing a custom command button did nothing when running without MQTT — the log only showed `Unsupported app WebSocket command received: <id>`. Built-in commands were unaffected. Each transport carried its own copy of the "what does this button mean" logic, and only the MQTT one knew about custom commands; all transports now share a single implementation, so they cannot drift apart again.
+- **The system service is now a first-class citizen on the HA API transport.** It had no channel of its own there — unlike MQTT, where the app and the service each advertise what they can handle and Home Assistant merges the two. Over the WebSocket the service announced itself *as the app*, advertising the tray app's commands and then refusing them, so with the tray app closed only commands enabled for both sides happened to work, and every button press left a stray warning in the log. The service now has its own channel, and Home Assistant names the side a command is meant for — so each press runs exactly once, on the right side, whether the tray app is running or not.
 
 Thanks to [@CookSleep](https://github.com/CookSleep) for the report — including the root cause and a suggested fix.
 

--- a/src/HASS.Agent.NET10/Mqtt/HaWebSocketService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/HaWebSocketService.cs
@@ -19,7 +19,7 @@ namespace HASS.Agent.Companion.Mqtt;
 internal sealed class HaWebSocketService : IDisposable
 {
     public const string IntegrationDomain = "hass_agent";
-    public const string MinimumIntegrationVersion = "10.2.0";
+    public const string MinimumIntegrationVersion = "10.6.5";
 
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
 
@@ -43,7 +43,12 @@ internal sealed class HaWebSocketService : IDisposable
     public event Action<MediaCommand>? MediaCommandReceived;
 
     /// <summary>Fired when a button/system command is received from HA via the event bus.</summary>
-    public event Action<SystemCommandMessage>? ButtonCommandReceived;
+    /// <summary>
+    /// Raised for an incoming button command. The second argument is the role the
+    /// integration addressed it to ("app"/"service"), or null when it came from an
+    /// older integration that does not target commands.
+    /// </summary>
+    public event Action<SystemCommandMessage, string?>? ButtonCommandReceived;
 
     public bool IsConnected => _ws is { State: WebSocketState.Open };
 
@@ -181,6 +186,16 @@ internal sealed class HaWebSocketService : IDisposable
     public async Task PublishDeviceDiscoveryAsync(object discoveryPayload, CancellationToken cancellationToken)
     {
         await FireEventAsync("hass_agent_device_update", discoveryPayload, cancellationToken);
+    }
+
+    /// <summary>
+    /// Publishes the system service's own status as a hass_agent_service_update event.
+    /// Mirrors the dedicated MQTT service topic: the app and the service each advertise
+    /// what they can handle, and the integration merges the two.
+    /// </summary>
+    public async Task PublishServiceStatusAsync(object statusPayload, CancellationToken cancellationToken)
+    {
+        await FireEventAsync("hass_agent_service_update", statusPayload, cancellationToken);
     }
 
     /// <summary>Publishes sensor state data as a hass_agent_sensor_update event.</summary>
@@ -573,7 +588,10 @@ internal sealed class HaWebSocketService : IDisposable
                         var command = JsonSerializer.Deserialize<SystemCommandMessage>(btnPayload.GetRawText(), JsonOptions);
                         if (command is not null)
                         {
-                            ButtonCommandReceived?.Invoke(command);
+                            var target = data.TryGetProperty("target", out var targetElement)
+                                ? targetElement.GetString()
+                                : null;
+                            ButtonCommandReceived?.Invoke(command, target);
                         }
                     }
                     break;

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -467,7 +467,21 @@ internal sealed class MqttCompanionService : IDisposable
             // delete them instead of keeping them (greyed out) until the device is back.
             if (_role == CompanionRuntimeRole.Service)
             {
-                await PublishDiscoveryAsync(offline: true);
+                if (_isOnWebSocket && _haWs is not null)
+                {
+                    // The WebSocket has no Last Will, so a stopping service has to say so
+                    // itself — otherwise Home Assistant keeps routing commands to it.
+                    // None: this must still send after the worker token is cancelled.
+                    await _haWs.PublishServiceStatusAsync(new
+                    {
+                        serial_number = _settings.SerialNumber,
+                        status = BuildServiceStatus(online: false)
+                    }, CancellationToken.None);
+                }
+                else
+                {
+                    await PublishDiscoveryAsync(offline: true);
+                }
             }
         }
         if (_mediaSessionService is not null)
@@ -533,8 +547,17 @@ internal sealed class MqttCompanionService : IDisposable
                     _ = _mediaSessionService.HandleCommandAsync(command);
                 }
             };
-            _haWs.ButtonCommandReceived += command =>
+            _haWs.ButtonCommandReceived += (command, target) =>
             {
+                // Over MQTT the integration routes by topic; over the WebSocket every
+                // instance sees the same event, so it names the role it meant instead.
+                // Older integrations send no target — then each role judges for itself,
+                // which is how it behaved before.
+                if (target is not null && !string.Equals(target, _role.Token(), StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
                 _ = ExecuteButtonCommandAsync(
                     command,
                     serviceRole: _role == CompanionRuntimeRole.Service,
@@ -816,6 +839,19 @@ internal sealed class MqttCompanionService : IDisposable
 
     private async Task PublishDiscoveryViaWebSocketAsync(CancellationToken cancellationToken)
     {
+        // The service has its own channel, exactly like its dedicated MQTT topic: it must
+        // not announce itself as the app, or it would advertise tray-app capabilities and
+        // then refuse the very commands it advertised.
+        if (_role == CompanionRuntimeRole.Service)
+        {
+            await _haWs!.PublishServiceStatusAsync(new
+            {
+                serial_number = _settings.SerialNumber,
+                status = BuildServiceStatus(online: true)
+            }, cancellationToken);
+            return;
+        }
+
         var systemSensorsEnabled = _settings.MqttSystemSensorsEnabled;
         var buttonsEnabled = _settings.MqttButtonsEnabled;
 

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -454,10 +454,27 @@ internal sealed class MqttCompanionService : IDisposable
             return;
         }
 
+        // The WebSocket has no Last Will, so a stopping service has to announce itself —
+        // and it must do so *before* cancelling: cancellation unwinds the WebSocket worker,
+        // which clears _isOnWebSocket and disconnects. Nothing re-publishes service status
+        // afterwards, so sending it early cannot be overwritten.
+        var announcedServiceOffline = false;
+        if (publishOffline && _role == CompanionRuntimeRole.Service && _isOnWebSocket && _haWs is not null)
+        {
+            await _haWs.PublishServiceStatusAsync(new
+            {
+                serial_number = _settings.SerialNumber,
+                status = BuildServiceStatus(online: false)
+            }, CancellationToken.None);
+            announcedServiceOffline = true;
+        }
+
         await _cts.CancelAsync();
 
         if (publishOffline)
         {
+            // Availability stays after cancellation on purpose: the heartbeat would
+            // otherwise race us and mark the device online again.
             await PublishAvailabilityAsync(online: false);
 
             // Only the service role publishes an offline state here: that just tells Home
@@ -465,23 +482,9 @@ internal sealed class MqttCompanionService : IDisposable
             // its discovery — the availability topic above already marks the entities
             // unavailable, and publishing empty capabilities would make Home Assistant
             // delete them instead of keeping them (greyed out) until the device is back.
-            if (_role == CompanionRuntimeRole.Service)
+            if (_role == CompanionRuntimeRole.Service && !announcedServiceOffline)
             {
-                if (_isOnWebSocket && _haWs is not null)
-                {
-                    // The WebSocket has no Last Will, so a stopping service has to say so
-                    // itself — otherwise Home Assistant keeps routing commands to it.
-                    // None: this must still send after the worker token is cancelled.
-                    await _haWs.PublishServiceStatusAsync(new
-                    {
-                        serial_number = _settings.SerialNumber,
-                        status = BuildServiceStatus(online: false)
-                    }, CancellationToken.None);
-                }
-                else
-                {
-                    await PublishDiscoveryAsync(offline: true);
-                }
+                await PublishDiscoveryAsync(offline: true);
             }
         }
         if (_mediaSessionService is not null)


### PR DESCRIPTION
Follow-up to #26, pairing with [Integration#6](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration/pull/6). Folded into the unreleased **10.6.5** rather than cutting another release.

## The problem
Over MQTT the app and the service each advertise what they can handle on their own topic, and the integration merges the two. The WebSocket had **no service channel** — so the service announced itself *as the app*, advertising `TrayAppCommands` and tray-scope custom commands, and then authorised incoming commands with **service** scope. Consequences:

- with the tray app closed, only commands enabled for **both** sides happened to work — by accident, not design
- every button press left a stray `Unsupported ... command received` from whichever instance did not recognise it (the very message that opened #26)
- a command enabled on both sides could run twice

## The fix
- The service publishes **`hass_agent_service_update`** — its existing service status, the same one it already puts on its MQTT topic — instead of impersonating the app's device discovery. It also reports `online: false` on a graceful stop, since the WebSocket has no Last Will to do it.
- Incoming WebSocket commands honour the **target role** the integration names, mirroring how MQTT routes by topic. Older integrations send no target: each role then judges for itself, exactly as before.
- `MinimumIntegrationVersion` moves to **10.6.5**, so HA API users get told to update the integration. That check only runs on the WebSocket path, so MQTT users never see it.

## Why not the smaller fix
The obvious one-liner — let only the app handle WebSocket commands — would have broken the case where the **tray app is not running**, which is exactly what the service exists for. Thanks to @v1k70rk4 for catching that before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom command targeting over WebSocket transport.
  * Added dedicated service status reporting for system-service connections.
  * WebSocket commands can now target the tray app or system service.

* **Bug Fixes**
  * Prevented non-targeted app instances from handling commands intended for another runtime role.
  * Improved offline status reporting when the system service disconnects.

* **Documentation**
  * Documented custom WebSocket commands and updated the minimum required Home Assistant integration version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->