### PR TITLE
Report service capabilities even while the service is stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 
 ### 10.6.6
 
+> 🚧 **Not released yet** — in testing. There is no download for this version on the Releases page.
+
 Requires the Home Assistant integration **10.6.6** or newer.
 
 - **Closing the tray app no longer takes the whole device offline.** With the Windows service installed, everything in Home Assistant turned unavailable the moment the tray app was closed or you logged out — even though the service was still running and reporting CPU, memory and disk. Only the tray app ever published the device's availability, so leaving declared the *device* dead rather than just itself. The tray app and the service are now treated as two independent providers: the device stays reachable while either is running, and each entity follows whichever side actually feeds it. Entities that only the tray app can provide (media player, active window, notifications) go **unavailable** rather than disappearing, and come straight back when it starts again.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/Windows-10%202004%2B%20%7C%2011-0078D4?logo=windows&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
-![Version](https://img.shields.io/badge/version-10.6.5-brightgreen)
+![Version](https://img.shields.io/badge/version-10.6.6-brightgreen)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-MQTT%20%7C%20WebSocket%20API-41BDF5?logo=homeassistant&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![Website](https://img.shields.io/badge/website-v1k70rk4.github.io-41bdf5?logo=github)](https://v1k70rk4.github.io/HASS.Agent.NET10/)
@@ -55,6 +55,15 @@ The modern .NET10 line starts at **version 10.0.0**. The pre-.NET10 client remai
 ---
 
 ## What Changed
+
+### 10.6.6
+
+Requires the Home Assistant integration **10.6.6** or newer.
+
+- **Closing the tray app no longer takes the whole device offline.** With the Windows service installed, everything in Home Assistant turned unavailable the moment the tray app was closed or you logged out — even though the service was still running and reporting CPU, memory and disk. Only the tray app ever published the device's availability, so leaving declared the *device* dead rather than just itself. The tray app and the service are now treated as two independent providers: the device stays reachable while either is running, and each entity follows whichever side actually feeds it. Entities that only the tray app can provide (media player, active window, notifications) go **unavailable** rather than disappearing, and come straight back when it starts again.
+- **A stopped provider no longer deletes its entities.** The service used to report an empty capability list while offline, so Home Assistant removed its sensors instead of greying them out. It now always reports what it handles, and reports separately whether it is running — so its entities stay put and simply show as unavailable. Turning a capability off in the settings still removes those entities, as it should.
+
+Thanks to [@Taomyn](https://github.com/Taomyn) for the report.
 
 ### 10.6.5
 
@@ -174,7 +183,7 @@ Stable release of the custom commands & command sensors line.
 - Home Assistant with **MQTT broker** (recommended, e.g. Mosquitto) **or HA API** (WebSocket, e.g. via Nabu Casa)
 - The companion Home Assistant integration:
   [v1k70rk4/HASS.Agent.NET10-Integration](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration) —
-  **version 10.6.5 or newer** (the agent and the integration are released with matching version numbers,
+  **version 10.6.6 or newer** (the agent and the integration are released with matching version numbers,
   so keep them in step; the HA API transport in particular needs 10.6.5+)
 
 Windows versions older than Windows 10 2004 are intentionally blocked. The app targets `net10.0-windows10.0.19041.0` and uses modern Windows APIs for notifications, media sessions, services, sensors, and desktop state.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Stable release of the custom commands & command sensors line.
 - The companion Home Assistant integration:
   [v1k70rk4/HASS.Agent.NET10-Integration](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration) —
   **version 10.6.6 or newer** (the agent and the integration are released with matching version numbers,
-  so keep them in step; the HA API transport in particular needs 10.6.5+)
+  so keep them in step)
 
 Windows versions older than Windows 10 2004 are intentionally blocked. The app targets `net10.0-windows10.0.19041.0` and uses modern Windows APIs for notifications, media sessions, services, sensors, and desktop state.
 

--- a/installer/HASS.Agent.NET10.iss
+++ b/installer/HASS.Agent.NET10.iss
@@ -1,5 +1,5 @@
 ﻿#ifndef MyAppVersion
-#define MyAppVersion "10.6.5"
+#define MyAppVersion "10.6.6"
 #endif
 
 #define MyAppName "HASS.Agent .NET10"

--- a/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
+++ b/src/HASS.Agent.NET10/HASS.Agent.NET10.csproj
@@ -13,7 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
-    <Version>10.6.5</Version>
+    <Version>10.6.6</Version>
     <Company>v1k70rk4</Company>
     <Authors>v1k70rk4</Authors>
     <Description>Modern .NET 10 Windows client for the HASS.Agent Home Assistant integration.</Description>

--- a/src/HASS.Agent.NET10/Mqtt/HaWebSocketService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/HaWebSocketService.cs
@@ -19,7 +19,7 @@ namespace HASS.Agent.Companion.Mqtt;
 internal sealed class HaWebSocketService : IDisposable
 {
     public const string IntegrationDomain = "hass_agent";
-    public const string MinimumIntegrationVersion = "10.6.5";
+    public const string MinimumIntegrationVersion = "10.6.6";
 
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
 

--- a/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
+++ b/src/HASS.Agent.NET10/Mqtt/MqttCompanionService.cs
@@ -1440,19 +1440,26 @@ internal sealed class MqttCompanionService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Builds the service's own status. "online" says whether the service is running;
+    /// the descriptors say what it handles when it does, and are reported either way —
+    /// an offline service that reported nothing would make Home Assistant delete its
+    /// entities instead of showing them as unavailable. A capability the user actually
+    /// turned off still reports as empty, so those entities do go away.
+    /// </summary>
     private MqttServiceStatusMessage BuildServiceStatus(bool online)
     {
-        var systemSensorsEnabled = online && _settings.MqttServiceSystemSensorsEnabled;
+        var systemSensorsEnabled = _settings.MqttServiceSystemSensorsEnabled;
 
         return new MqttServiceStatusMessage(
             online,
             _role.Token(),
-            online ? BuildCommandDescriptors(_settings.ServiceCommands) : [],
+            BuildCommandDescriptors(_settings.ServiceCommands),
             systemSensorsEnabled,
             systemSensorsEnabled ? BuildCustomSensorDescriptors(serviceRole: true) : [],
             systemSensorsEnabled ? BuildStandardSensorDescriptors(serviceRole: true) : [],
             DateTimeOffset.UtcNow,
-            online ? BuildCustomCommandDescriptors(serviceRole: true) : []);
+            BuildCustomCommandDescriptors(serviceRole: true));
     }
 
     private static IReadOnlyList<SystemCommandDescriptor> BuildCommandDescriptors(IEnumerable<string> commands)


### PR DESCRIPTION
Client side of #32, paired with [Integration#7](https://github.com/v1k70rk4/HASS.Agent.NET10-Integration/pull/7). Reproduced on a second machine too: with the service installed, closing the tray app takes *everything* in Home Assistant offline, even though the service keeps running and publishing.

## This change
The service's status payload used `online` to gate its **own descriptors**:

```csharp
online ? BuildCommandDescriptors(_settings.ServiceCommands) : []
```

So a stopped service reported "I handle nothing", and Home Assistant removed its entities rather than showing them unavailable.

`online` now says only **whether the service is running**; the descriptors say **what it handles when it does**, and are reported either way. A capability the user actually switched off still reports empty — which is exactly the distinction the integration needs to tell *stopped* from *disabled*.

The rest of the fix (device availability from either provider, per-entity greying out) lives in the integration.

## Versions
Bumps to **10.6.6** and raises `MinimumIntegrationVersion` to match, so HA API users are told to update the integration. That check only runs on the WebSocket path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Service capabilities and system sensor availability remain visible in Home Assistant while the service is offline.
  - Entities for stopped providers are preserved instead of being removed.

- **Documentation**
  - Updated release documentation with version 10.6.6 details and Home Assistant integration requirements.

- **Maintenance**
  - Updated the application, installer, and Home Assistant integration version to 10.6.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->